### PR TITLE
Bugfix/38

### DIFF
--- a/packages/chip/package-lock.json
+++ b/packages/chip/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/chip",
-  "version": "0.1.6",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/input/src/chameleon-input.ts
+++ b/packages/input/src/chameleon-input.ts
@@ -5,10 +5,11 @@ import {
   html,
   property
 } from "lit-element";
-import { nothing } from "lit-html";
+import { nothing, svg, SVGTemplateResult } from "lit-html";
 import { classMap } from "lit-html/directives/class-map";
 import base from "@chameleon-ds/theme/base";
 import style from "@chameleon-ds/theme/base/input";
+import { isNullOrUndefined } from "util";
 
 @customElement("chameleon-input")
 export default class ChameleonInput extends LitElement {
@@ -82,7 +83,9 @@ export default class ChameleonInput extends LitElement {
     return html`
       ${this.labelText}
       <div
-        class="${classMap({
+        class="
+        ${classMap({
+          invalid: this._invalidState,
           "input-wrapper": true,
           "icon-left": this["icon-left"],
           "icon-right": this["icon-right"]
@@ -163,7 +166,9 @@ export default class ChameleonInput extends LitElement {
   get labelText(): TemplateResult | object {
     if (this.label !== "") {
       return html`
-        <label for="cha-input">${this.label}</label>
+        <label for="cha-input" class="${this._invalidState ? "invalid" : ""}"
+          >${this.label}</label
+        >
       `;
     } else return nothing;
   }
@@ -171,7 +176,7 @@ export default class ChameleonInput extends LitElement {
   get errorText(): TemplateResult | object {
     if (this.validationMessage !== "") {
       return html`
-        <span class="error">${this.validationMessage}</span>
+        <span class="error">${this.warningIcon}</slot>${this.validationMessage}</span>
       `;
     } else return nothing;
   }
@@ -191,6 +196,14 @@ export default class ChameleonInput extends LitElement {
     else return false;
   }
 
+  get _invalidState(): boolean {
+    if (this._el !== null) {
+      if (!this.validity.valid || this.validationMessage.length > 0) {
+        return true;
+      } else return false;
+    }
+  }
+
   _handleInput(e: any): void {
     // e must have a value of `any` right now because of: https://stackoverflow.com/a/57331338/3713527
     this.value = e.target.value;
@@ -203,5 +216,26 @@ export default class ChameleonInput extends LitElement {
   _handleInvalid(): void {
     this.validationMessage =
       this._el !== null ? this._el.validationMessage : "";
+  }
+
+  get warningIcon(): SVGTemplateResult {
+    return svg`
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="feather feather-search"
+  >
+  <circle cx="12" cy="12" r="10" />
+  <line x1="12" y1="8" x2="12" y2="12" />
+  <line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+  `;
   }
 }

--- a/packages/input/src/chameleon-input.ts
+++ b/packages/input/src/chameleon-input.ts
@@ -9,10 +9,18 @@ import { nothing, svg, SVGTemplateResult } from "lit-html";
 import { classMap } from "lit-html/directives/class-map";
 import base from "@chameleon-ds/theme/base";
 import style from "@chameleon-ds/theme/base/input";
-import { isNullOrUndefined } from "util";
 
 @customElement("chameleon-input")
 export default class ChameleonInput extends LitElement {
+  /**
+   * Lifecycle Methods
+   */
+  firstUpdated() {
+    // TODO(ryuhhnn): This isn't the best strategy for hydrating in the
+    // correct error state. Come back to this to come up with better solution.
+    this.requestUpdate();
+  }
+
   /**
    * Properties
    */
@@ -166,7 +174,9 @@ export default class ChameleonInput extends LitElement {
   get labelText(): TemplateResult | object {
     if (this.label !== "") {
       return html`
-        <label for="cha-input" class="${this._invalidState ? "invalid" : ""}"
+        <label
+          for="cha-input"
+          class="${classMap({ invalid: this._invalidState })}"
           >${this.label}</label
         >
       `;
@@ -198,7 +208,7 @@ export default class ChameleonInput extends LitElement {
 
   get _invalidState(): boolean {
     if (this._el !== null) {
-      if (!this.validity.valid || this.validationMessage.length > 0) {
+      if (!this.checkValidity() || this.validationMessage.length > 0) {
         return true;
       } else return false;
     }
@@ -210,7 +220,8 @@ export default class ChameleonInput extends LitElement {
   }
 
   _handleBlur(): void {
-    this.checkValidity();
+    const elementValid = this.checkValidity();
+    if (elementValid) this.validationMessage = "";
   }
 
   _handleInvalid(): void {
@@ -220,22 +231,22 @@ export default class ChameleonInput extends LitElement {
 
   get warningIcon(): SVGTemplateResult {
     return svg`
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    class="feather feather-search"
-  >
-  <circle cx="12" cy="12" r="10" />
-  <line x1="12" y1="8" x2="12" y2="12" />
-  <line x1="12" y1="16" x2="12.01" y2="16" />
-    </svg>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="feather feather-search"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" y1="8" x2="12" y2="12" />
+        <line x1="12" y1="16" x2="12.01" y2="16" />
+      </svg>
   `;
   }
 }

--- a/packages/input/src/chameleon-input.ts
+++ b/packages/input/src/chameleon-input.ts
@@ -176,7 +176,7 @@ export default class ChameleonInput extends LitElement {
   get errorText(): TemplateResult | object {
     if (this.validationMessage !== "") {
       return html`
-        <span class="error">${this.warningIcon}</slot>${this.validationMessage}</span>
+        <span class="error">${this.warningIcon} ${this.validationMessage}</span>
       `;
     } else return nothing;
   }
@@ -222,8 +222,8 @@ export default class ChameleonInput extends LitElement {
     return svg`
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
+    width="14"
+    height="14"
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"

--- a/packages/theme/base/index.ts
+++ b/packages/theme/base/index.ts
@@ -26,5 +26,6 @@ export default css`
     --font-size-title: 1.4em;
     --font-size-input: 0.938em;
     --font-size-label: 0.875em;
+    --font-family: Arial, Helvetica, sans-serif;
   }
 `;

--- a/packages/theme/base/input/index.ts
+++ b/packages/theme/base/input/index.ts
@@ -4,6 +4,7 @@ export default css`
   :host {
     display: inline-flex;
     flex-direction: column;
+    font-family: var(--font-family);
   }
 
   input {
@@ -30,6 +31,11 @@ export default css`
     color: var(--color-error);
     font-size: var(--font-size-label);
     margin-top: 3px;
+    display: flex;
+    align-items: center;
+  }
+  .error svg {
+    padding-right: 0.5rem;
   }
 
   .input-wrapper {

--- a/packages/theme/base/input/index.ts
+++ b/packages/theme/base/input/index.ts
@@ -12,6 +12,7 @@ export default css`
     border-radius: var(--border-radius-input);
     box-sizing: border-box;
     font-size: var(--font-size-input);
+    font-family: var(--font-family);
     max-width: 100%;
     padding: var(--input-padding);
   }

--- a/packages/theme/base/input/index.ts
+++ b/packages/theme/base/input/index.ts
@@ -15,12 +15,17 @@ export default css`
     padding: var(--input-padding);
   }
 
+  .invalid input {
+    border-color: var(--color-error);
+  }
   label {
     color: var(--color-gray-darkest);
     font-size: var(--font-size-label);
     margin-bottom: 10px;
   }
-
+  label.invalid {
+    color: var(--color-error);
+  }
   .error {
     color: var(--color-error);
     font-size: var(--font-size-label);

--- a/packages/theme/base/input/index.ts
+++ b/packages/theme/base/input/index.ts
@@ -20,14 +20,21 @@ export default css`
   .invalid input {
     border-color: var(--color-error);
   }
+
+  .invalid ::slotted(svg) {
+    color: var(--color-error);
+  }
+
   label {
     color: var(--color-gray-darkest);
     font-size: var(--font-size-label);
     margin-bottom: 10px;
   }
+
   label.invalid {
     color: var(--color-error);
   }
+
   .error {
     color: var(--color-error);
     font-size: var(--font-size-label);
@@ -35,6 +42,7 @@ export default css`
     display: flex;
     align-items: center;
   }
+
   .error svg {
     padding-right: 0.5rem;
   }

--- a/packages/theme/package-lock.json
+++ b/packages/theme/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/theme",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Adding error color to input border and label when input is invalid, as well as adding warning icon. To test, in Storybook set the input type to email, then enter anything without an '@' in the input and tab out. 