### PR TITLE
added custom event upon closing toast

### DIFF
--- a/packages/toast/src/chameleon-toast.ts
+++ b/packages/toast/src/chameleon-toast.ts
@@ -57,5 +57,11 @@ export default class ChameleonToast extends LitElement {
   closeToast() {
     const x = this.shadowRoot.getElementById("toast");
     x.className = x.className.replace("show-closeable", "");
+    this.dispatchEvent(
+      new CustomEvent("close-toast", {
+        bubbles: true,
+        composed: true
+      })
+    );
   }
 }


### PR DESCRIPTION
I initially forgot to put this in. I need an close-toast event to listen to on the parent component so I can keep track of the fact that the user has closed the toast.