### PR TITLE
Fix full width button in a flex parent

### DIFF
--- a/packages/theme/base/button/index.ts
+++ b/packages/theme/base/button/index.ts
@@ -5,6 +5,10 @@ export default css`
     display: inline;
   }
 
+  :host([full-width]) {
+    flex: 1;
+  }
+
   :host([full-width]) button {
     width: 100%;
   }


### PR DESCRIPTION
Adds flex: 1 to a full width button so it'll be full width inside a flex parent.

https://github.com/MaritzSTL/chameleon/issues/83