### PR TITLE
docs(yarn): updates instructions to use yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The Chameleon project relies on some awesome tools in order to work properly. Yo
 - [Node.js](https://nodejs.org) - JavaScript runtime built on Chrome's V8 JavaScript Engine (this project uses v12.7.0)
 - [Git](https://git-scm.com/downloads) - Version control software for cloning this repository
 - [NVM (Node Version Manager)](https://github.com/nvm-sh/nvm) - A bash script to manage multiple active node.js versions
+- [Yarn](https://yarnpkg.com/lang/en/) - Package manager used for Yarn workspaces
 
 ## Setup
 
@@ -24,23 +25,23 @@ The Chameleon project relies on some awesome tools in order to work properly. Yo
 To setup Chameleon for development, run the following in your folder of choice:
 
 ```bash
-git clone git@github.com:MaritzSTL/chameleon.git && cd chameleon && nvm use && npm run setup
+git clone git@github.com:MaritzSTL/chameleon.git && cd chameleon && nvm use && yarn setup
 ```
 
 Chameleon uses storybook for development, so when you're ready to get going just run:
 
 ```bash
-npm run dev
+yarn dev
 ```
 
 To build each element and package for distribution, run:
 
 ```bash
-npm run build
+yarn build
 ```
 
 If something looks wrong or you need to refresh your dependencies for whatever reason you can run:
 
 ```bash
-npm run clean
+yarn clean
 ```


### PR DESCRIPTION
Since the switch to yarn workspaces, using `npm` won't work.

Updates instructions in readme.

Please note, it's not required to say `run` - you can say `yarn dev` and that's the same as `yarn run dev`.