### PR TITLE
Add options to add an anchor href to a button and set target _blank

### DIFF
--- a/.storybook/stories/button.stories.ts
+++ b/.storybook/stories/button.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/polymer";
-import { withKnobs, boolean } from "@storybook/addon-knobs";
+import { withKnobs, boolean, text } from "@storybook/addon-knobs";
 import { html, svg } from "lit-html";
 import "../../packages/button/src/chameleon-button";
 
@@ -22,14 +22,20 @@ stories.add(
   () => {
     const disabled = boolean("Disabled", false);
     const fullWidth = boolean("Full Width", false);
+    const href = text("Link", "");
+    const newTab = boolean("Open Link in New Tab", false);
 
     return html`
-      <chameleon-button
-        ?disabled="${disabled}"
-        theme="primary"
-        ?full-width="${fullWidth}"
-        >Button</chameleon-button
-      >
+      <div style="display: flex;">
+        <chameleon-button
+          ?disabled="${disabled}"
+          theme="primary"
+          ?full-width="${fullWidth}"
+          href=${href}
+          ?new-tab=${newTab}
+          >Button</chameleon-button
+        >
+      </div>
     `;
   },
   { info: { inline: true } }
@@ -40,12 +46,16 @@ stories.add(
   () => {
     const disabled = boolean("Disabled", false);
     const fullWidth = boolean("Full Width", false);
+    const href = text("Link", "");
+    const newTab = boolean("Open Link in New Tab", false);
 
     return html`
       <chameleon-button
         ?disabled="${disabled}"
         theme="secondary"
         ?full-width="${fullWidth}"
+        href=${href}
+        ?new-tab=${newTab}
         >Button</chameleon-button
       >
     `;
@@ -58,12 +68,16 @@ stories.add(
   () => {
     const disabled = boolean("Disabled", false);
     const fullWidth = boolean("Full Width", false);
+    const href = text("Link", "");
+    const newTab = boolean("Open Link in New Tab", false);
 
     return html`
       <chameleon-button
         ?disabled="${disabled}"
         theme="text"
         ?full-width="${fullWidth}"
+        href=${href}
+        ?new-tab=${newTab}
         >Button</chameleon-button
       >
     `;
@@ -76,6 +90,8 @@ stories.add(
   () => {
     const disabled = boolean("Disabled", false);
     const fullWidth = boolean("Full Width", false);
+    const href = text("Link", "");
+    const newTab = boolean("Open Link in New Tab", false);
 
     return html`
       <chameleon-button
@@ -83,6 +99,8 @@ stories.add(
         theme="text"
         ?full-width="${fullWidth}"
         icon-left
+        href=${href}
+        ?new-tab=${newTab}
         >${plusIcon("icon-left")}Add</chameleon-button
       >
     `;
@@ -94,9 +112,16 @@ stories.add(
   "Icon Only",
   () => {
     const disabled = boolean("Disabled", false);
+    const href = text("Link", "");
+    const newTab = boolean("Open Link in New Tab", false);
 
     return html`
-      <chameleon-button ?disabled="${disabled}" icon-only theme="text"
+      <chameleon-button
+        ?disabled="${disabled}"
+        icon-only
+        theme="text"
+        href=${href}
+        ?new-tab=${newTab}
         >${arrowIcon("icon-only")}</chameleon-button
       >
     `;

--- a/packages/button/__tests__/chameleon-button.test.ts
+++ b/packages/button/__tests__/chameleon-button.test.ts
@@ -8,4 +8,75 @@ describe("chameleon-button", () => {
     `);
     expect(Boolean(el.shadowRoot)).to.equal(true);
   });
+
+  it("renders as a button when no href is set", async () => {
+    const el = await fixture(
+      html`
+        <chameleon-button></chameleon-button>
+      `
+    );
+    expect(Boolean(el.shadowRoot.querySelector(":host > button"))).to.equal(
+      true
+    );
+    expect(Boolean(el.shadowRoot.querySelector(":host > a"))).to.equal(false);
+  });
+
+  it("renders as a link when an href is set", async () => {
+    const el = await fixture(
+      html`
+        <chameleon-button
+          href="https://github.com/MaritzSTL/chameleon"
+        ></chameleon-button>
+      `
+    );
+
+    expect(Boolean(el.shadowRoot.querySelector(":host > a"))).to.equal(true);
+    expect(Boolean(el.shadowRoot.querySelector(":host > button"))).to.equal(
+      false
+    );
+  });
+
+  it("anchor sets target to _top when new-tab is missing", async () => {
+    const el = await fixture(
+      html`
+        <chameleon-button
+          href="https://github.com/MaritzSTL/chameleon"
+        ></chameleon-button>
+      `
+    );
+
+    expect(
+      Boolean(el.shadowRoot.querySelector(":host > a[target='_top']"))
+    ).to.equal(true);
+  });
+
+  it("anchor sets target to _top when new-tab is false", async () => {
+    const el = await fixture(
+      html`
+        <chameleon-button
+          href="https://github.com/MaritzSTL/chameleon"
+          ?new-tab="${false}"
+        ></chameleon-button>
+      `
+    );
+
+    expect(
+      Boolean(el.shadowRoot.querySelector(":host > a[target='_top']"))
+    ).to.equal(true);
+  });
+
+  it("anchor sets target to _blank when new-tab is true", async () => {
+    const el = await fixture(
+      html`
+        <chameleon-button
+          href="https://github.com/MaritzSTL/chameleon"
+          new-tab="true"
+        ></chameleon-button>
+      `
+    );
+
+    expect(
+      Boolean(el.shadowRoot.querySelector(":host > a[target='_blank']"))
+    ).to.equal(true);
+  });
 });

--- a/packages/button/src/chameleon-button.ts
+++ b/packages/button/src/chameleon-button.ts
@@ -50,7 +50,11 @@ export default class ChameleonButton extends LitElement {
     return html`
       ${this.href && !this.disabled
         ? html`
-            <a href=${this.href} target=${this.getTarget()}>
+            <a
+              href=${this.href}
+              target=${this.getTarget()}
+              rel=${this.getRel()}
+            >
               ${this.renderButton()}
             </a>
           `
@@ -76,5 +80,9 @@ export default class ChameleonButton extends LitElement {
 
   getTarget(): string {
     return this["new-tab"] ? `_blank` : `_top`;
+  }
+
+  getRel(): string {
+    return this["new-tab"] ? `noopener noreferrer` : ``;
   }
 }

--- a/packages/button/src/chameleon-button.ts
+++ b/packages/button/src/chameleon-button.ts
@@ -30,6 +30,14 @@ export default class ChameleonButton extends LitElement {
   @property({ type: Boolean, reflect: true })
   "icon-only" = false;
 
+  // Element has an href
+  @property({ type: String, reflect: true })
+  "href" = "";
+
+  // Element should open href in new tab/window
+  @property({ type: Boolean, reflect: true })
+  "new-tab" = false;
+
   /**
    * Styles
    */
@@ -39,6 +47,20 @@ export default class ChameleonButton extends LitElement {
    * Template
    */
   render(): TemplateResult {
+    return html`
+      ${this.href && !this.disabled
+        ? html`
+            <a href=${this.href} target=${this.getTarget()}>
+              ${this.renderButton()}
+            </a>
+          `
+        : html`
+            ${this.renderButton()}
+          `}
+    `;
+  }
+
+  renderButton(): TemplateResult {
     return html`
       <button
         class="${classMap({ [this.theme]: true })}"
@@ -50,5 +72,9 @@ export default class ChameleonButton extends LitElement {
         <slot name="icon-only"></slot>
       </button>
     `;
+  }
+
+  getTarget(): string {
+    return this["new-tab"] ? `_blank` : `_top`;
   }
 }

--- a/packages/theme/base/button/index.ts
+++ b/packages/theme/base/button/index.ts
@@ -9,8 +9,15 @@ export default css`
     flex: 1;
   }
 
+  :host([full-width]) a,
   :host([full-width]) button {
+    flex: 1;
     width: 100%;
+  }
+
+  a {
+    display: inline-block;
+    text-decoration: none;
   }
 
   button[disabled] {


### PR DESCRIPTION
If an href property is added to the chameleon-button, the button is wrapped in an anchor tag.
Also adds an option to open the href in a new tab if set.

https://github.com/MaritzSTL/chameleon/issues/95