### PR TITLE
override vertical-align baseline

### DIFF
--- a/packages/theme/base/checkbox/index.ts
+++ b/packages/theme/base/checkbox/index.ts
@@ -10,6 +10,7 @@ export default css`
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
+    vertical-align: middle;
   }
 
   input {

--- a/packages/theme/base/checkbox/index.ts
+++ b/packages/theme/base/checkbox/index.ts
@@ -10,7 +10,7 @@ export default css`
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
-    vertical-align: middle;
+    vertical-align: top;
   }
 
   input {


### PR DESCRIPTION
Closes #31 

Because :host has a display of inline-flex the margins/heights get a little wonky.  The options are to override the baseline vertical-align or change the display.

[Here's a post explaining inline vertical align baseline.](https://stackoverflow.com/questions/48117071/element-with-display-inline-flex-has-a-strange-top-margin)