### PR TITLE
Hotfix/module import interop

### DIFF
--- a/.storybook/stories/button.stories.ts
+++ b/.storybook/stories/button.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/polymer";
 import { withKnobs, boolean, text } from "@storybook/addon-knobs";
 import { html, svg } from "lit-html";
-import "../../packages/button/src/chameleon-button";
+import "@chameleon-ds/button/src/chameleon-button";
 
 const stories = storiesOf("Button", module);
 

--- a/.storybook/stories/card.stories.ts
+++ b/.storybook/stories/card.stories.ts
@@ -1,11 +1,11 @@
 import { storiesOf } from "@storybook/polymer";
 import { withKnobs, boolean, text } from "@storybook/addon-knobs";
 import { html } from "lit-html";
-import "../../packages/card/src/chameleon-card";
-import "../../packages/card-header/src/chameleon-card-header";
-import "../../packages/card-image/src/chameleon-card-image";
-import "../../packages/card-footer/src/chameleon-card-footer";
-import "../../packages/button/src/chameleon-button";
+import "@chameleon-ds/card/src/chameleon-card";
+import "@chameleon-ds/card-header/src/chameleon-card-header";
+import "@chameleon-ds/card-image/src/chameleon-card-image";
+import "@chameleon-ds/card-footer/src/chameleon-card-footer";
+import "@chameleon-ds/button/src/chameleon-button";
 
 const stories = storiesOf("Card", module);
 

--- a/.storybook/stories/checkbox.stories.ts
+++ b/.storybook/stories/checkbox.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/polymer";
 import { withKnobs, boolean, text } from "@storybook/addon-knobs";
 import { html } from "lit-html";
-import "../../packages/checkbox/src/chameleon-checkbox";
+import "@chameleon-ds/checkbox/src/chameleon-checkbox";
 
 const stories = storiesOf("Checkbox", module);
 

--- a/.storybook/stories/chip.stories.ts
+++ b/.storybook/stories/chip.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/polymer";
 import { withKnobs } from "@storybook/addon-knobs";
 import { html, svg } from "lit-html";
-import "../../packages/chip/src/chameleon-chip";
+import "@chameleon-ds/chip/src/chameleon-chip";
 
 const stories = storiesOf("Chip", module);
 

--- a/.storybook/stories/hero.stories.ts
+++ b/.storybook/stories/hero.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/polymer";
 import { withKnobs, text, number, boolean } from "@storybook/addon-knobs";
 import { html } from "lit-html";
-import "../../packages/hero/src/chameleon-hero";
+import "@chameleon-ds/hero/src/chameleon-hero";
 
 const stories = storiesOf("Hero", module);
 

--- a/.storybook/stories/input.stories.ts
+++ b/.storybook/stories/input.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/polymer";
 import { withKnobs, boolean, radios, text } from "@storybook/addon-knobs";
 import { html, svg } from "lit-html";
-import "../../packages/input/src/chameleon-input";
+import "@chameleon-ds/input/src/chameleon-input";
 
 const stories = storiesOf("Input", module);
 

--- a/.storybook/stories/loader.stories.ts
+++ b/.storybook/stories/loader.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/polymer";
 import { withKnobs, text } from "@storybook/addon-knobs";
 import { html } from "lit-html";
-import "../../packages/loader/src/chameleon-loader";
+import "@chameleon-ds/loader/src/chameleon-loader";
 
 const stories = storiesOf("Loader", module);
 

--- a/.storybook/stories/paginator.stories.ts
+++ b/.storybook/stories/paginator.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/polymer";
 import { withKnobs, number } from "@storybook/addon-knobs";
 import { html } from "lit-html";
-import "../../packages/paginator/src/chameleon-paginator";
+import "@chameleon-ds/paginator/src/chameleon-paginator";
 
 const stories = storiesOf("Paginator", module);
 

--- a/.storybook/stories/radio.stories.ts
+++ b/.storybook/stories/radio.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/polymer";
 import { withKnobs, boolean, text } from "@storybook/addon-knobs";
 import { html } from "lit-html";
-import "../../packages/radio/src/chameleon-radio";
+import "@chameleon-ds/radio/src/chameleon-radio";
 
 const stories = storiesOf("Radio", module);
 

--- a/.storybook/stories/rice-ball-dessert.stories.ts
+++ b/.storybook/stories/rice-ball-dessert.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/polymer";
 import { withKnobs, text } from "@storybook/addon-knobs";
 import { html } from "lit-html";
-import "../../packages/rice-ball-dessert/src/chameleon-rice-ball-dessert";
+import "@chameleon-ds/rice-ball-dessert/src/chameleon-rice-ball-dessert";
 
 const stories = storiesOf("Rice Ball Dessert", module);
 

--- a/.storybook/stories/sheet.stories.ts
+++ b/.storybook/stories/sheet.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/polymer";
 import { withKnobs, boolean, text } from "@storybook/addon-knobs";
 import { html } from "lit-html";
-import "../../packages/sheet/src/chameleon-sheet";
+import "@chameleon-ds/sheet/src/chameleon-sheet";
 
 const stories = storiesOf("Sheet", module);
 

--- a/.storybook/stories/skeleton.stories.ts
+++ b/.storybook/stories/skeleton.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/polymer";
 import { withKnobs, text } from "@storybook/addon-knobs";
 import { html } from "lit-html";
-import "../../packages/skeleton/src/chameleon-skeleton";
+import "@chameleon-ds/skeleton/src/chameleon-skeleton";
 
 const stories = storiesOf("Skeleton", module);
 

--- a/.storybook/stories/switch.stories.ts
+++ b/.storybook/stories/switch.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/polymer";
 import { withKnobs, boolean, text } from "@storybook/addon-knobs";
 import { html } from "lit-html";
-import "../../packages/switch/src/chameleon-switch";
+import "@chameleon-ds/switch/src/chameleon-switch";
 
 const stories = storiesOf("Switch", module);
 

--- a/.storybook/stories/tabs.stories.ts
+++ b/.storybook/stories/tabs.stories.ts
@@ -1,8 +1,7 @@
 import { storiesOf } from "@storybook/polymer";
 import { withKnobs } from "@storybook/addon-knobs";
 import { html } from "lit-html";
-import "../../packages/tabs/src/chameleon-tabs";
-import "../../packages/tabs/src/chameleon-tab";
+import "@chameleon-ds/tabs/src/index";
 
 const stories = storiesOf("Tabs", module);
 

--- a/.storybook/stories/textarea.stories.ts
+++ b/.storybook/stories/textarea.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/polymer";
 import { withKnobs, boolean, text, number } from "@storybook/addon-knobs";
 import { html } from "lit-html";
-import "../../packages/textarea/src/chameleon-textarea";
+import "@chameleon-ds/textarea/src/chameleon-textarea";
 
 const stories = storiesOf("Textarea", module);
 

--- a/.storybook/stories/toast.stories.ts
+++ b/.storybook/stories/toast.stories.ts
@@ -1,8 +1,7 @@
 import { storiesOf } from "@storybook/polymer";
 import { withKnobs, text, boolean } from "@storybook/addon-knobs";
 import { html } from "lit-html";
-import "../../packages/toast/src/chameleon-toast";
-import "../../packages/toast/src/chameleon-toast";
+import "@chameleon-ds/toast/src/chameleon-toast";
 
 const stories = storiesOf("Toast", module);
 

--- a/.storybook/webpack.config.ts
+++ b/.storybook/webpack.config.ts
@@ -11,5 +11,11 @@ module.exports = ({ config }: { config: webpack.Configuration }) => {
     ]
   });
   config!.resolve!.extensions!.push(".ts");
+  config!.resolve!.alias!["@chameleon-ds/loader"] =
+    "@chameleon-ds/loader/src/chameleon-loader";
+  config!.resolve!.alias!["@chameleon-ds/button"] =
+    "@chameleon-ds/button/src/chameleon-button";
+  config!.resolve!.alias!["@chameleon-ds/skeleton"] =
+    "@chameleon-ds/skeleton/src/chameleon-skeleton";
   return config;
 };

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/storybook__polymer": "^5.1.0",
     "@types/webpack": "^4.39.5",
     "@types/webpack-env": "^1.14.0",
+    "@webcomponents/webcomponentsjs": "^2.3.0",
     "awesome-typescript-loader": "^5.2.1",
     "babel-loader": "^8.0.6",
     "codecov": "^3.6.1",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/MaritzSTL/chameleon/issues"
   },
   "dependencies": {
-    "@chameleon-ds/loader": "1.1.1",
+    "@chameleon-ds/loader": "^1.1.1",
     "lit-element": "^2.2.1"
   },
   "publishConfig": {

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-button.js",
-  "module": "chameleon-button.js",
+  "main": "src/chameleon-button.js",
+  "module": "src/chameleon-button.js",
   "files": [
-    "/src/",
-    "/chameleon-button-style.d.ts",
-    "/chameleon-button-style.d.ts.map",
-    "/chameleon-button-style.js",
-    "/chameleon-button-style.js.map",
-    "/chameleon-button.d.ts",
-    "/chameleon-button.d.ts.map",
-    "/chameleon-button.js",
-    "/chameleon-button.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",
@@ -30,7 +22,6 @@
     "url": "https://github.com/MaritzSTL/chameleon/issues"
   },
   "dependencies": {
-    "@chameleon-ds/loader": "^1.1.0",
     "lit-element": "^2.2.1"
   },
   "publishConfig": {

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/button",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Chameleon button",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -22,6 +22,7 @@
     "url": "https://github.com/MaritzSTL/chameleon/issues"
   },
   "dependencies": {
+    "@chameleon-ds/loader": "1.1.1",
     "lit-element": "^2.2.1"
   },
   "publishConfig": {

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-button.js",
-  "module": "src/chameleon-button.js",
+  "main": "dist/chameleon-button.js",
+  "module": "dist/chameleon-button.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/button/src/chameleon-button.ts
+++ b/packages/button/src/chameleon-button.ts
@@ -8,7 +8,7 @@ import {
 import { nothing } from "lit-html";
 import { classMap } from "lit-html/directives/class-map";
 import style from "./chameleon-button-style";
-import "@chameleon-ds/loader/src/chameleon-loader";
+import "@chameleon-ds/loader";
 
 @customElement("chameleon-button")
 export default class ChameleonButton extends LitElement {

--- a/packages/button/tsconfig.json
+++ b/packages/button/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/button/tsconfig.json
+++ b/packages/button/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/card-footer/package.json
+++ b/packages/card-footer/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-card-footer.js",
-  "module": "src/chameleon-card-footer.js",
+  "main": "dist/chameleon-card-footer.js",
+  "module": "dist/chameleon-card-footer.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/card-footer/package.json
+++ b/packages/card-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/card-footer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Chameleon card footer",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/card-footer/package.json
+++ b/packages/card-footer/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-card-footer.js",
-  "module": "chameleon-card-footer.js",
+  "main": "src/chameleon-card-footer.js",
+  "module": "src/chameleon-card-footer.js",
   "files": [
-    "/src/",
-    "/chameleon-card-footer-style.d.ts",
-    "/chameleon-card-footer-style.d.ts.map",
-    "/chameleon-card-footer-style.js",
-    "/chameleon-card-footer-style.js.map",
-    "/chameleon-card-footer.d.ts",
-    "/chameleon-card-footer.d.ts.map",
-    "/chameleon-card-footer.js",
-    "/chameleon-card-footer.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/card-footer/tsconfig.json
+++ b/packages/card-footer/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/card-footer/tsconfig.json
+++ b/packages/card-footer/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/card-header/package.json
+++ b/packages/card-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/card-header",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Chameleon card header",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/card-header/package.json
+++ b/packages/card-header/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-card-header.js",
-  "module": "chameleon-card-header.js",
+  "main": "src/chameleon-card-header.js",
+  "module": "src/chameleon-card-header.js",
   "files": [
-    "/src/",
-    "/chameleon-card-header-style.d.ts",
-    "/chameleon-card-header-style.d.ts.map",
-    "/chameleon-card-header-style.js",
-    "/chameleon-card-header-style.js.map",
-    "/chameleon-card-header.d.ts",
-    "/chameleon-card-header.d.ts.map",
-    "/chameleon-card-header.js",
-    "/chameleon-card-header.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/card-header/package.json
+++ b/packages/card-header/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-card-header.js",
-  "module": "src/chameleon-card-header.js",
+  "main": "dist/chameleon-card-header.js",
+  "module": "dist/chameleon-card-header.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/card-header/tsconfig.json
+++ b/packages/card-header/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/card-header/tsconfig.json
+++ b/packages/card-header/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/card-image/package.json
+++ b/packages/card-image/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-card-image.js",
-  "module": "chameleon-card-image.js",
+  "main": "src/chameleon-card-image.js",
+  "module": "src/chameleon-card-image.js",
   "files": [
-    "/src/",
-    "/chameleon-card-image-style.d.ts",
-    "/chameleon-card-image-style.d.ts.map",
-    "/chameleon-card-image-style.js",
-    "/chameleon-card-image-style.js.map",
-    "/chameleon-card-image.d.ts",
-    "/chameleon-card-image.d.ts.map",
-    "/chameleon-card-image.js",
-    "/chameleon-card-image.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/card-image/package.json
+++ b/packages/card-image/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-card-image.js",
-  "module": "src/chameleon-card-image.js",
+  "main": "dist/chameleon-card-image.js",
+  "module": "dist/chameleon-card-image.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/card-image/package.json
+++ b/packages/card-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/card-image",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Chameleon card image",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/card-image/tsconfig.json
+++ b/packages/card-image/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/card-image/tsconfig.json
+++ b/packages/card-image/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-card.js",
-  "module": "chameleon-card.js",
+  "main": "src/chameleon-card.js",
+  "module": "src/chameleon-card.js",
   "files": [
-    "/src/",
-    "/chameleon-card-style.d.ts",
-    "/chameleon-card-style.d.ts.map",
-    "/chameleon-card-style.js",
-    "/chameleon-card-style.js.map",
-    "/chameleon-card.d.ts",
-    "/chameleon-card.d.ts.map",
-    "/chameleon-card.js",
-    "/chameleon-card.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-card.js",
-  "module": "src/chameleon-card.js",
+  "main": "dist/chameleon-card.js",
+  "module": "dist/chameleon-card.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/card",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Chameleon card",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/card/tsconfig.json
+++ b/packages/card/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/card/tsconfig.json
+++ b/packages/card/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/checkbox",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Chameleon checkbox",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-checkbox.js",
-  "module": "src/chameleon-checkbox.js",
+  "main": "dist/chameleon-checkbox.js",
+  "module": "dist/chameleon-checkbox.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-checkbox.js",
-  "module": "chameleon-checkbox.js",
+  "main": "src/chameleon-checkbox.js",
+  "module": "src/chameleon-checkbox.js",
   "files": [
-    "/src/",
-    "/chameleon-checkbox-style.d.ts",
-    "/chameleon-checkbox-style.d.ts.map",
-    "/chameleon-checkbox-style.js",
-    "/chameleon-checkbox-style.js.map",
-    "/chameleon-checkbox.d.ts",
-    "/chameleon-checkbox.d.ts.map",
-    "/chameleon-checkbox.js",
-    "/chameleon-checkbox.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/checkbox/tsconfig.json
+++ b/packages/checkbox/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/checkbox/tsconfig.json
+++ b/packages/checkbox/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/chip/package.json
+++ b/packages/chip/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-chip.js",
-  "module": "src/chameleon-chip.js",
+  "main": "dist/chameleon-chip.js",
+  "module": "dist/chameleon-chip.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/chip/package.json
+++ b/packages/chip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/chip",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Chameleon chip",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/chip/package.json
+++ b/packages/chip/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-chip.js",
-  "module": "chameleon-chip.js",
+  "main": "src/chameleon-chip.js",
+  "module": "src/chameleon-chip.js",
   "files": [
-    "/src/",
-    "/chameleon-chip-style.d.ts",
-    "/chameleon-chip-style.d.ts.map",
-    "/chameleon-chip-style.js",
-    "/chameleon-chip-style.js.map",
-    "/chameleon-chip.d.ts",
-    "/chameleon-chip.d.ts.map",
-    "/chameleon-chip.js",
-    "/chameleon-chip.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/chip/tsconfig.json
+++ b/packages/chip/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/chip/tsconfig.json
+++ b/packages/chip/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/hero/package.json
+++ b/packages/hero/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-hero.js",
-  "module": "chameleon-hero.js",
+  "main": "src/chameleon-hero.js",
+  "module": "src/chameleon-hero.js",
   "files": [
-    "/src/",
-    "/chameleon-hero-style.d.ts",
-    "/chameleon-hero-style.d.ts.map",
-    "/chameleon-hero-style.js",
-    "/chameleon-hero-style.js.map",
-    "/chameleon-hero.d.ts",
-    "/chameleon-hero.d.ts.map",
-    "/chameleon-hero.js",
-    "/chameleon-hero.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/hero/package.json
+++ b/packages/hero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/hero",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Chameleon hero",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "url": "https://github.com/MaritzSTL/chameleon/issues"
   },
   "dependencies": {
-    "@chameleon-ds/skeleton": "^1.0.0",
+    "@chameleon-ds/skeleton": "^1.0.1",
     "lit-element": "^2.2.1"
   },
   "publishConfig": {

--- a/packages/hero/package.json
+++ b/packages/hero/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-hero.js",
-  "module": "src/chameleon-hero.js",
+  "main": "dist/chameleon-hero.js",
+  "module": "dist/chameleon-hero.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/hero/src/chameleon-hero.ts
+++ b/packages/hero/src/chameleon-hero.ts
@@ -8,7 +8,7 @@ import {
 import { styleMap } from "lit-html/directives/style-map.js";
 import { nothing } from "lit-html";
 import style from "./chameleon-hero-style";
-import "@chameleon-ds/skeleton/src/chameleon-skeleton";
+import "@chameleon-ds/skeleton";
 
 @customElement("chameleon-hero")
 export default class ChameleonHero extends LitElement {

--- a/packages/hero/tsconfig.json
+++ b/packages/hero/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/hero/tsconfig.json
+++ b/packages/hero/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-input.js",
-  "module": "src/chameleon-input.js",
+  "main": "dist/chameleon-input.js",
+  "module": "dist/chameleon-input.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-input.js",
-  "module": "chameleon-input.js",
+  "main": "src/chameleon-input.js",
+  "module": "src/chameleon-input.js",
   "files": [
-    "/src/",
-    "/chameleon-input-style.d.ts",
-    "/chameleon-input-style.d.ts.map",
-    "/chameleon-input-style.js",
-    "/chameleon-input-style.js.map",
-    "/chameleon-input.d.ts",
-    "/chameleon-input.d.ts.map",
-    "/chameleon-input.js",
-    "/chameleon-input.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/input",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Chameleon input",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/input/tsconfig.json
+++ b/packages/input/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/input/tsconfig.json
+++ b/packages/input/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/loader",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Chameleon loader",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-loader.js",
-  "module": "src/chameleon-loader.js",
+  "main": "dist/chameleon-loader.js",
+  "module": "dist/chameleon-loader.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -9,22 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-loader.js",
-  "module": "chameleon-loader.js",
+  "main": "src/chameleon-loader.js",
+  "module": "src/chameleon-loader.js",
   "files": [
-    "/src/",
-    "/chameleon-loader-style.d.ts",
-    "/chameleon-loader-style.d.ts.map",
-    "/chameleon-loader-style.js",
-    "/chameleon-loader-style.js.map",
-    "/materialize-loader-style.d.ts",
-    "/materialize-loader-style.d.ts.map",
-    "/materialize-loader-style.js",
-    "/materialize-loader-style.js.map",
-    "/chameleon-loader.d.ts",
-    "/chameleon-loader.d.ts.map",
-    "/chameleon-loader.js",
-    "/chameleon-loader.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/loader/tsconfig.json
+++ b/packages/loader/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/loader/tsconfig.json
+++ b/packages/loader/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/paginator/package.json
+++ b/packages/paginator/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-paginator.js",
-  "module": "src/chameleon-paginator.js",
+  "main": "dist/chameleon-paginator.js",
+  "module": "dist/chameleon-paginator.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/paginator/package.json
+++ b/packages/paginator/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "index.js",
-  "module": "index.js",
+  "main": "src/chameleon-paginator.js",
+  "module": "src/chameleon-paginator.js",
   "files": [
-    "/src/",
-    "/chameleon-paginator-style.d.ts",
-    "/chameleon-paginator-style.d.ts.map",
-    "/chameleon-paginator-style.js",
-    "/chameleon-paginator-style.js.map",
-    "/chameleon-paginator.d.ts",
-    "/chameleon-paginator.d.ts.map",
-    "/chameleon-paginator.js",
-    "/chameleon-paginator.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/paginator/package.json
+++ b/packages/paginator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/paginator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Chameleon paginator",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "url": "https://github.com/MaritzSTL/chameleon/issues"
   },
   "dependencies": {
-    "@chameleon-ds/button": "^1.0.0",
+    "@chameleon-ds/button": "^1.0.2",
     "lit-element": "^2.2.1"
   },
   "publishConfig": {

--- a/packages/paginator/src/chameleon-paginator.ts
+++ b/packages/paginator/src/chameleon-paginator.ts
@@ -9,7 +9,7 @@ import {
 } from "lit-element";
 import { nothing } from "lit-html";
 import style from "./chameleon-paginator-style";
-import "@chameleon-ds/button/src/chameleon-button";
+import "@chameleon-ds/button";
 
 @customElement("chameleon-paginator")
 export default class ChameleonPaginator extends LitElement {

--- a/packages/paginator/tsconfig.json
+++ b/packages/paginator/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/paginator/tsconfig.json
+++ b/packages/paginator/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-radio.js",
-  "module": "src/chameleon-radio.js",
+  "main": "dist/chameleon-radio.js",
+  "module": "dist/chameleon-radio.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/radio",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Chameleon radio",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-radio.js",
-  "module": "chameleon-radio.js",
+  "main": "src/chameleon-radio.js",
+  "module": "src/chameleon-radio.js",
   "files": [
-    "/src/",
-    "/chameleon-radio-style.d.ts",
-    "/chameleon-radio-style.d.ts.map",
-    "/chameleon-radio-style.js",
-    "/chameleon-radio-style.js.map",
-    "/chameleon-radio.d.ts",
-    "/chameleon-radio.d.ts.map",
-    "/chameleon-radio.js",
-    "/chameleon-radio.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/radio/tsconfig.json
+++ b/packages/radio/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/radio/tsconfig.json
+++ b/packages/radio/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/rice-ball-dessert/package.json
+++ b/packages/rice-ball-dessert/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-rice-ball-dessert.js",
-  "module": "src/chameleon-rice-ball-dessert.js",
+  "main": "dist/chameleon-rice-ball-dessert.js",
+  "module": "dist/chameleon-rice-ball-dessert.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/rice-ball-dessert/package.json
+++ b/packages/rice-ball-dessert/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-rice-ball-dessert.js",
-  "module": "chameleon-rice-ball-dessert.js",
+  "main": "src/chameleon-rice-ball-dessert.js",
+  "module": "src/chameleon-rice-ball-dessert.js",
   "files": [
-    "/src/",
-    "/chameleon-rice-ball-dessert-style.d.ts",
-    "/chameleon-rice-ball-dessert-style.d.ts.map",
-    "/chameleon-rice-ball-dessert-style.js",
-    "/chameleon-rice-ball-dessert-style.js.map",
-    "/chameleon-rice-ball-dessert.d.ts",
-    "/chameleon-rice-ball-dessert.d.ts.map",
-    "/chameleon-rice-ball-dessert.js",
-    "/chameleon-rice-ball-dessert.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/rice-ball-dessert/package.json
+++ b/packages/rice-ball-dessert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/rice-ball-dessert",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Chameleon rice ball dessert",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/rice-ball-dessert/tsconfig.json
+++ b/packages/rice-ball-dessert/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/rice-ball-dessert/tsconfig.json
+++ b/packages/rice-ball-dessert/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/sheet/package.json
+++ b/packages/sheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/sheet",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Chameleon sheet",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/sheet/package.json
+++ b/packages/sheet/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-sheet.js",
-  "module": "src/chameleon-sheet.js",
+  "main": "dist/chameleon-sheet.js",
+  "module": "dist/chameleon-sheet.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/sheet/package.json
+++ b/packages/sheet/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-sheet.js",
-  "module": "chameleon-sheet.js",
+  "main": "src/chameleon-sheet.js",
+  "module": "src/chameleon-sheet.js",
   "files": [
-    "/src/",
-    "/chameleon-sheet-style.d.ts",
-    "/chameleon-sheet-style.d.ts.map",
-    "/chameleon-sheet-style.js",
-    "/chameleon-sheet-style.js.map",
-    "/chameleon-sheet.d.ts",
-    "/chameleon-sheet.d.ts.map",
-    "/chameleon-sheet.js",
-    "/chameleon-sheet.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/sheet/tsconfig.json
+++ b/packages/sheet/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/sheet/tsconfig.json
+++ b/packages/sheet/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/skeleton",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Chameleon skeleton",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-skeleton.js",
-  "module": "chameleon-skeleton.js",
+  "main": "src/chameleon-skeleton.js",
+  "module": "src/chameleon-skeleton.js",
   "files": [
-    "/src/",
-    "/chameleon-skeleton-style.d.ts",
-    "/chameleon-skeleton-style.d.ts.map",
-    "/chameleon-skeleton-style.js",
-    "/chameleon-skeleton-style.js.map",
-    "/chameleon-skeleton.d.ts",
-    "/chameleon-skeleton.d.ts.map",
-    "/chameleon-skeleton.js",
-    "/chameleon-skeleton.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-skeleton.js",
-  "module": "src/chameleon-skeleton.js",
+  "main": "dist/chameleon-skeleton.js",
+  "module": "dist/chameleon-skeleton.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/skeleton/tsconfig.json
+++ b/packages/skeleton/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/skeleton/tsconfig.json
+++ b/packages/skeleton/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-switch.js",
-  "module": "src/chameleon-switch.js",
+  "main": "dist/chameleon-switch.js",
+  "module": "dist/chameleon-switch.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-switch.js",
-  "module": "chameleon-switch.js",
+  "main": "src/chameleon-switch.js",
+  "module": "src/chameleon-switch.js",
   "files": [
-    "/src/",
-    "/chameleon-switch-style.d.ts",
-    "/chameleon-switch-style.d.ts.map",
-    "/chameleon-switch-style.js",
-    "/chameleon-switch-style.js.map",
-    "/chameleon-switch.d.ts",
-    "/chameleon-switch.d.ts.map",
-    "/chameleon-switch.js",
-    "/chameleon-switch.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/switch",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Chameleon switch",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/switch/tsconfig.json
+++ b/packages/switch/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/switch/tsconfig.json
+++ b/packages/switch/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/tabs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Chameleon tabs",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/index.js",
-  "module": "src/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -9,26 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "index.js",
-  "module": "index.js",
+  "main": "src/index.js",
+  "module": "src/index.js",
   "files": [
-    "/src/",
-    "/chameleon-tabs-style.d.ts",
-    "/chameleon-tabs-style.d.ts.map",
-    "/chameleon-tabs-style.js",
-    "/chameleon-tabs-style.js.map",
-    "/chameleon-tab.d.ts",
-    "/chameleon-tab.d.ts.map",
-    "/chameleon-tab.js",
-    "/chameleon-tab.js.map",
-    "/chameleon-tabs.d.ts",
-    "/chameleon-tabs.d.ts.map",
-    "/chameleon-tabs.js",
-    "/chameleon-tabs.js.map",
-    "/index.d.ts",
-    "/index.d.ts.map",
-    "/index.js",
-    "/index.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/tabs/tsconfig.json
+++ b/packages/tabs/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/tabs/tsconfig.json
+++ b/packages/tabs/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-textarea.js",
-  "module": "src/chameleon-textarea.js",
+  "main": "dist/chameleon-textarea.js",
+  "module": "dist/chameleon-textarea.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/textarea",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Chameleon textarea",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-textarea.js",
-  "module": "chameleon-textarea.js",
+  "main": "src/chameleon-textarea.js",
+  "module": "src/chameleon-textarea.js",
   "files": [
-    "/src/",
-    "/chameleon-textarea-style.d.ts",
-    "/chameleon-textarea-style.d.ts.map",
-    "/chameleon-textarea-style.js",
-    "/chameleon-textarea-style.js.map",
-    "/chameleon-textarea.d.ts",
-    "/chameleon-textarea.d.ts.map",
-    "/chameleon-textarea.js",
-    "/chameleon-textarea.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/textarea/tsconfig.json
+++ b/packages/textarea/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/textarea/tsconfig.json
+++ b/packages/textarea/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/toast",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Chameleon toast",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -9,10 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "src/chameleon-toast.js",
-  "module": "src/chameleon-toast.js",
+  "main": "dist/chameleon-toast.js",
+  "module": "dist/chameleon-toast.js",
   "files": [
-    "/src/"
+    "/src/",
+    "/dist/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -9,18 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "chameleon-toast.js",
-  "module": "chameleon-toast.js",
+  "main": "src/chameleon-toast.js",
+  "module": "src/chameleon-toast.js",
   "files": [
-    "/src/",
-    "/chameleon-toast-style.d.ts",
-    "/chameleon-toast-style.d.ts.map",
-    "/chameleon-toast-style.js",
-    "/chameleon-toast-style.js.map",
-    "/chameleon-toast.d.ts",
-    "/chameleon-toast.d.ts.map",
-    "/chameleon-toast.js",
-    "/chameleon-toast.js.map"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/toast/tsconfig.json
+++ b/packages/toast/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/toast/tsconfig.json
+++ b/packages/toast/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -719,11 +719,6 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@chameleon-ds/loader@/Users/colemar/Workspace/chameleon/packages/loader":
-  version "1.1.0"
-  dependencies:
-    lit-element "^2.2.1"
-
 "@comandeer/babel-plugin-banner@^5.0.0":
   version "5.0.0"
   resolved "https://registry.npmjs.org/@comandeer/babel-plugin-banner/-/babel-plugin-banner-5.0.0.tgz#30969cb08e810b67810d41761d0cfac292231ea9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -719,6 +719,11 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@chameleon-ds/loader@/Users/colemar/Workspace/chameleon/packages/loader":
+  version "1.1.0"
+  dependencies:
+    lit-element "^2.2.1"
+
 "@comandeer/babel-plugin-banner@^5.0.0":
   version "5.0.0"
   resolved "https://registry.npmjs.org/@comandeer/babel-plugin-banner/-/babel-plugin-banner-5.0.0.tgz#30969cb08e810b67810d41761d0cfac292231ea9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2455,7 +2455,7 @@
   resolved "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.3.3.tgz#5bb82a0d3210c836bd4623e13a4a93145cb9dc27"
   integrity sha512-eLH04VBMpuZGzBIhOnUjECcQPEPcmfhWEijW9u1B5I+2PPYdWf3vWUExdDxu4Y3GljRSTCOlWnGtS9tpzmXMyQ==
 
-"@webcomponents/webcomponentsjs@^2.2.10":
+"@webcomponents/webcomponentsjs@^2.2.10", "@webcomponents/webcomponentsjs@^2.3.0":
   version "2.3.0"
   resolved "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.3.0.tgz#d17c67e9602d46f5a6c425bc00613bba83dcd0e2"
   integrity sha512-sR6FOrNnnncRuoJDqq9QxtRsJMbIvASw4vnJwIYKVlKO3AMc+NAr/bIQNnUiTTE9pBDTJkFpVaUdjJaRdsjmyA==


### PR DESCRIPTION
This PR should rework the build system to output to the /src/ directory so that packages can be ingested by either TS or JS files without the need for additional loaders or weird dependency issues.