### PR TITLE
Fix karma testing

### DIFF
--- a/packages/button/__tests__/chameleon-button.test.ts
+++ b/packages/button/__tests__/chameleon-button.test.ts
@@ -1,5 +1,5 @@
 import { fixture, html, expect } from "@open-wc/testing";
-import "../src/chameleon-button";
+import "@chameleon-ds/button/src/chameleon-button";
 
 describe("chameleon-button", () => {
   it("renders", async () => {

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-button.js",
-  "module": "dist/chameleon-button.js",
+  "main": "src/chameleon-button.js",
+  "module": "src/chameleon-button.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/button",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Chameleon button",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "url": "https://github.com/MaritzSTL/chameleon/issues"
   },
   "dependencies": {
-    "@chameleon-ds/loader": "^1.1.1",
+    "@chameleon-ds/loader": "^1.2.0",
     "lit-element": "^2.2.1"
   },
   "publishConfig": {

--- a/packages/button/src/chameleon-button.ts
+++ b/packages/button/src/chameleon-button.ts
@@ -8,7 +8,7 @@ import {
 import { nothing } from "lit-html";
 import { classMap } from "lit-html/directives/class-map";
 import style from "./chameleon-button-style";
-import "@chameleon-ds/loader";
+import "@chameleon-ds/loader/src/chameleon-loader";
 
 @customElement("chameleon-button")
 export default class ChameleonButton extends LitElement {

--- a/packages/button/tsconfig.json
+++ b/packages/button/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/card-footer/__tests__/chameleon-card-footer.test.ts
+++ b/packages/card-footer/__tests__/chameleon-card-footer.test.ts
@@ -1,5 +1,5 @@
 import { litFixture, html, expect } from "@open-wc/testing";
-import "../src/chameleon-card-footer";
+import "@chameleon-ds/card-footer/src/chameleon-card-footer";
 
 describe("chameleon-card-footer", () => {
   it("renders", async () => {

--- a/packages/card-footer/package.json
+++ b/packages/card-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/card-footer",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Chameleon card footer",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/card-footer/package.json
+++ b/packages/card-footer/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-card-footer.js",
-  "module": "dist/chameleon-card-footer.js",
+  "main": "src/chameleon-card-footer.js",
+  "module": "src/chameleon-card-footer.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/card-footer/tsconfig.json
+++ b/packages/card-footer/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/card-header/__tests__/chameleon-card-header.test.ts
+++ b/packages/card-header/__tests__/chameleon-card-header.test.ts
@@ -1,5 +1,5 @@
 import { litFixture, html, expect } from "@open-wc/testing";
-import "../src/chameleon-card-header";
+import "@chameleon-ds/card-header/src/chameleon-card-header";
 
 const fixture = html`
   <chameleon-card-header></chameleon-card-header>

--- a/packages/card-header/package.json
+++ b/packages/card-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/card-header",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Chameleon card header",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/card-header/package.json
+++ b/packages/card-header/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-card-header.js",
-  "module": "dist/chameleon-card-header.js",
+  "main": "src/chameleon-card-header.js",
+  "module": "src/chameleon-card-header.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/card-header/tsconfig.json
+++ b/packages/card-header/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/card-image/__tests__/chameleon-card-image.test.ts
+++ b/packages/card-image/__tests__/chameleon-card-image.test.ts
@@ -1,5 +1,5 @@
 import { fixture, html, expect } from "@open-wc/testing";
-import "../src/chameleon-card-image";
+import "@chameleon-ds/card-image/src/chameleon-card-image";
 
 describe("chameleon-card-image", () => {
   it("renders", async () => {

--- a/packages/card-image/package.json
+++ b/packages/card-image/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-card-image.js",
-  "module": "dist/chameleon-card-image.js",
+  "main": "src/chameleon-card-image.js",
+  "module": "src/chameleon-card-image.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/card-image/package.json
+++ b/packages/card-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/card-image",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Chameleon card image",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/card-image/tsconfig.json
+++ b/packages/card-image/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/card/__tests__/chameleon-card.test.ts
+++ b/packages/card/__tests__/chameleon-card.test.ts
@@ -1,6 +1,6 @@
 import { litFixture, html, expect } from "@open-wc/testing";
-import "../src/chameleon-card";
-import ChameleonCard from "../src/chameleon-card";
+import "@chameleon-ds/card/src/chameleon-card";
+import ChameleonCard from "@chameleon-ds/card/src/chameleon-card";
 
 describe("chameleon-card", () => {
   it("renders", async () => {

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/card",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Chameleon card",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-card.js",
-  "module": "dist/chameleon-card.js",
+  "main": "src/chameleon-card.js",
+  "module": "src/chameleon-card.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/card/tsconfig.json
+++ b/packages/card/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/checkbox/__tests__/chameleon-checkbox.test.ts
+++ b/packages/checkbox/__tests__/chameleon-checkbox.test.ts
@@ -1,5 +1,5 @@
 import { litFixture, html, expect } from "@open-wc/testing";
-import "../src/chameleon-checkbox";
+import "@chameleon-ds/checkbox/src/chameleon-checkbox";
 
 const fixture = html`
   <chameleon-checkbox></chameleon-checkbox>

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-checkbox.js",
-  "module": "dist/chameleon-checkbox.js",
+  "main": "src/chameleon-checkbox.js",
+  "module": "src/chameleon-checkbox.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/checkbox",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Chameleon checkbox",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/checkbox/tsconfig.json
+++ b/packages/checkbox/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/chip/__tests__/chameleon-chip.test.ts
+++ b/packages/chip/__tests__/chameleon-chip.test.ts
@@ -1,5 +1,5 @@
 import { fixture, html, expect } from "@open-wc/testing";
-import "../src/chameleon-chip";
+import "@chameleon-ds/chip/src/chameleon-chip";
 
 describe("chameleon-chip", () => {
   it("renders", async () => {

--- a/packages/chip/package.json
+++ b/packages/chip/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-chip.js",
-  "module": "dist/chameleon-chip.js",
+  "main": "src/chameleon-chip.js",
+  "module": "src/chameleon-chip.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/chip/package.json
+++ b/packages/chip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/chip",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Chameleon chip",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/chip/tsconfig.json
+++ b/packages/chip/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/dialog/__tests__/chameleon-dialog.test.ts
+++ b/packages/dialog/__tests__/chameleon-dialog.test.ts
@@ -1,6 +1,6 @@
 import { litFixture, html, expect } from "@open-wc/testing";
 import sinon from "sinon";
-import "../src/chameleon-dialog";
+import "@chameleon-ds/dialog/src/chameleon-dialog";
 
 const fixture = html`
   <chameleon-dialog></chameleon-dialog>

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-dialog.js",
-  "module": "dist/chameleon-dialog.js",
+  "main": "src/chameleon-dialog.js",
+  "module": "src/chameleon-dialog.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -22,6 +22,8 @@
     "url": "https://github.com/MaritzSTL/chameleon/issues"
   },
   "dependencies": {
+    "@chameleon-ds/button": "^1.1.0",
+    "@chameleon-ds/card": "^1.1.0",
     "lit-element": "^2.2.1"
   },
   "publishConfig": {

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/dialog",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Chameleon dialog",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/dialog/src/chameleon-dialog.ts
+++ b/packages/dialog/src/chameleon-dialog.ts
@@ -9,7 +9,7 @@ import { nothing, svg, SVGTemplateResult } from "lit-html";
 import { classMap } from "lit-html/directives/class-map";
 import base from "@chameleon-ds/theme/base";
 import style from "./chameleon-dialog-style";
-import "../../card/src/chameleon-card";
+import "@chameleon-ds/card/src/chameleon-card";
 import "@chameleon-ds/button/src/chameleon-button";
 
 @customElement("chameleon-dialog")

--- a/packages/dialog/tsconfig.json
+++ b/packages/dialog/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/hero/__tests__/chameleon-hero.test.ts
+++ b/packages/hero/__tests__/chameleon-hero.test.ts
@@ -1,5 +1,5 @@
 import { litFixture, html, expect } from "@open-wc/testing";
-import "../src/chameleon-hero";
+import "@chameleon-ds/hero/src/chameleon-hero";
 
 const fixture = html`
   <chameleon-hero></chameleon-hero>

--- a/packages/hero/package.json
+++ b/packages/hero/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-hero.js",
-  "module": "dist/chameleon-hero.js",
+  "main": "src/chameleon-hero.js",
+  "module": "src/chameleon-hero.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/hero/package.json
+++ b/packages/hero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/hero",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Chameleon hero",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "url": "https://github.com/MaritzSTL/chameleon/issues"
   },
   "dependencies": {
-    "@chameleon-ds/skeleton": "^1.0.1",
+    "@chameleon-ds/skeleton": "^1.1.0",
     "lit-element": "^2.2.1"
   },
   "publishConfig": {

--- a/packages/hero/src/chameleon-hero.ts
+++ b/packages/hero/src/chameleon-hero.ts
@@ -8,7 +8,7 @@ import {
 import { styleMap } from "lit-html/directives/style-map.js";
 import { nothing } from "lit-html";
 import style from "./chameleon-hero-style";
-import "@chameleon-ds/skeleton";
+import "@chameleon-ds/skeleton/src/chameleon-skeleton";
 
 @customElement("chameleon-hero")
 export default class ChameleonHero extends LitElement {

--- a/packages/hero/tsconfig.json
+++ b/packages/hero/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/input/__tests__/chameleon-input.test.ts
+++ b/packages/input/__tests__/chameleon-input.test.ts
@@ -1,6 +1,6 @@
 import { litFixture, html, expect } from "@open-wc/testing";
 import sinon from "sinon";
-import "../src/chameleon-input";
+import "@chameleon-ds/input/src/chameleon-input";
 
 const fixture = html`
   <chameleon-input></chameleon-input>

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-input.js",
-  "module": "dist/chameleon-input.js",
+  "main": "src/chameleon-input.js",
+  "module": "src/chameleon-input.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/input",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Chameleon input",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/input/tsconfig.json
+++ b/packages/input/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/loader/__tests__/chameleon-loader.test.ts
+++ b/packages/loader/__tests__/chameleon-loader.test.ts
@@ -1,5 +1,5 @@
 import { fixture, html, expect } from "@open-wc/testing";
-import "../src/chameleon-loader";
+import "@chameleon-ds/loader/src/chameleon-loader";
 
 describe("chameleon-loader", () => {
   it("renders", async () => {

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/loader",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Chameleon loader",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-loader.js",
-  "module": "dist/chameleon-loader.js",
+  "main": "src/chameleon-loader.js",
+  "module": "src/chameleon-loader.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/loader/tsconfig.json
+++ b/packages/loader/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/paginator/__tests__/chameleon-paginator.test.ts
+++ b/packages/paginator/__tests__/chameleon-paginator.test.ts
@@ -1,6 +1,6 @@
 import { litFixture, html, expect } from "@open-wc/testing";
 import sinon from "sinon";
-import "../src/chameleon-paginator";
+import "@chameleon-ds/paginator/src/chameleon-paginator";
 
 const fixture = html`
   <chameleon-paginator totalItems="100" pageSize="10"></chameleon-paginator>

--- a/packages/paginator/package.json
+++ b/packages/paginator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/paginator",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Chameleon paginator",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "url": "https://github.com/MaritzSTL/chameleon/issues"
   },
   "dependencies": {
-    "@chameleon-ds/button": "^1.0.2",
+    "@chameleon-ds/button": "^1.1.0",
     "lit-element": "^2.2.1"
   },
   "publishConfig": {

--- a/packages/paginator/package.json
+++ b/packages/paginator/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-paginator.js",
-  "module": "dist/chameleon-paginator.js",
+  "main": "src/chameleon-paginator.js",
+  "module": "src/chameleon-paginator.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/paginator/src/chameleon-paginator.ts
+++ b/packages/paginator/src/chameleon-paginator.ts
@@ -9,7 +9,7 @@ import {
 } from "lit-element";
 import { nothing } from "lit-html";
 import style from "./chameleon-paginator-style";
-import "@chameleon-ds/button";
+import "@chameleon-ds/button/src/chameleon-button";
 
 @customElement("chameleon-paginator")
 export default class ChameleonPaginator extends LitElement {

--- a/packages/paginator/tsconfig.json
+++ b/packages/paginator/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/radio/__tests__/chameleon-radio.test.ts
+++ b/packages/radio/__tests__/chameleon-radio.test.ts
@@ -1,5 +1,5 @@
 import { litFixture, html, expect } from "@open-wc/testing";
-import "../src/chameleon-radio";
+import "@chameleon-ds/radio/src/chameleon-radio";
 
 const fixture = html`
   <chameleon-radio></chameleon-radio>

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/radio",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Chameleon radio",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-radio.js",
-  "module": "dist/chameleon-radio.js",
+  "main": "src/chameleon-radio.js",
+  "module": "src/chameleon-radio.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/radio/tsconfig.json
+++ b/packages/radio/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/rice-ball-dessert/__tests__/chameleon-rice-ball-dessert.test.ts
+++ b/packages/rice-ball-dessert/__tests__/chameleon-rice-ball-dessert.test.ts
@@ -1,5 +1,5 @@
 import { fixture, html, expect } from "@open-wc/testing";
-import "../src/chameleon-rice-ball-dessert";
+import "@chameleon-ds/rice-ball-dessert/src/chameleon-rice-ball-dessert";
 
 describe("chameleon-rice-ball-dessert", () => {
   it("renders", async () => {

--- a/packages/rice-ball-dessert/package.json
+++ b/packages/rice-ball-dessert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/rice-ball-dessert",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Chameleon rice ball dessert",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/rice-ball-dessert/package.json
+++ b/packages/rice-ball-dessert/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-rice-ball-dessert.js",
-  "module": "dist/chameleon-rice-ball-dessert.js",
+  "main": "src/chameleon-rice-ball-dessert.js",
+  "module": "src/chameleon-rice-ball-dessert.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/rice-ball-dessert/tsconfig.json
+++ b/packages/rice-ball-dessert/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/sheet/__tests__/chameleon-sheet.test.ts
+++ b/packages/sheet/__tests__/chameleon-sheet.test.ts
@@ -1,6 +1,6 @@
 import { litFixture, html, expect } from "@open-wc/testing";
 import sinon from "sinon";
-import "../src/chameleon-sheet";
+import "@chameleon-ds/sheet/src/chameleon-sheet";
 
 const fixture = html`
   <chameleon-sheet></chameleon-sheet>
@@ -24,7 +24,7 @@ describe("chameleon-sheet", () => {
 
     expect(element).shadowDom.to.equal(`
       <header class="head-container">
-        <div class="close-icon"></div>
+        <chameleon-button class="close-icon" href="" icon-only="" theme="text"></chameleon-button>
         <h3 class="header"></h3>
         <slot name="details"></slot>
       </header>

--- a/packages/sheet/package.json
+++ b/packages/sheet/package.json
@@ -22,6 +22,7 @@
     "url": "https://github.com/MaritzSTL/chameleon/issues"
   },
   "dependencies": {
+    "@chameleon-ds/button": "^1.1.0",
     "lit-element": "^2.2.1"
   },
   "publishConfig": {

--- a/packages/sheet/package.json
+++ b/packages/sheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/sheet",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Chameleon sheet",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/sheet/package.json
+++ b/packages/sheet/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-sheet.js",
-  "module": "dist/chameleon-sheet.js",
+  "main": "src/chameleon-sheet.js",
+  "module": "src/chameleon-sheet.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/sheet/tsconfig.json
+++ b/packages/sheet/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/skeleton/__tests__/chameleon-skeleton.test.ts
+++ b/packages/skeleton/__tests__/chameleon-skeleton.test.ts
@@ -1,5 +1,5 @@
 import { fixture, html, expect } from "@open-wc/testing";
-import "../src/chameleon-skeleton";
+import "@chameleon-ds/skeleton/src/chameleon-skeleton";
 
 describe("chameleon-skeleton", () => {
   it("renders", async () => {

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-skeleton.js",
-  "module": "dist/chameleon-skeleton.js",
+  "main": "src/chameleon-skeleton.js",
+  "module": "src/chameleon-skeleton.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/skeleton",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Chameleon skeleton",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/skeleton/tsconfig.json
+++ b/packages/skeleton/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/switch/__tests__/chameleon-switch.test.ts
+++ b/packages/switch/__tests__/chameleon-switch.test.ts
@@ -1,5 +1,5 @@
 import { litFixture, html, expect } from "@open-wc/testing";
-import "../src/chameleon-switch";
+import "@chameleon-ds/switch/src/chameleon-switch";
 
 const fixture = html`
   <chameleon-switch></chameleon-switch>

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/switch",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Chameleon switch",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-switch.js",
-  "module": "dist/chameleon-switch.js",
+  "main": "src/chameleon-switch.js",
+  "module": "src/chameleon-switch.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/switch/tsconfig.json
+++ b/packages/switch/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/tabs/__tests__/chameleon-tabs.test.ts
+++ b/packages/tabs/__tests__/chameleon-tabs.test.ts
@@ -1,8 +1,7 @@
 import { litFixture, html, expect } from "@open-wc/testing";
 import sinon from "sinon";
-import ChameleonTabs from "../src/chameleon-tabs";
-import "../src/chameleon-tabs";
-import "../src/chameleon-tab";
+import ChameleonTabs from "@chameleon-ds/tabs/src/chameleon-tabs";
+import "@chameleon-ds/tabs/src/index";
 
 const fixture = html`
   <chameleon-tabs><chameleon-tab></chameleon-tab></chameleon-tabs>

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/tabs",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Chameleon tabs",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "src/index.js",
+  "module": "src/index.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/tabs/tsconfig.json
+++ b/packages/tabs/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/textarea/__tests__/chameleon-textarea.test.ts
+++ b/packages/textarea/__tests__/chameleon-textarea.test.ts
@@ -1,6 +1,6 @@
 import { litFixture, html, expect } from "@open-wc/testing";
 import sinon from "sinon";
-import "../src/chameleon-textarea";
+import "@chameleon-ds/textarea/src/chameleon-textarea";
 
 const fixture = html`
   <chameleon-textarea></chameleon-textarea>

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-textarea.js",
-  "module": "dist/chameleon-textarea.js",
+  "main": "src/chameleon-textarea.js",
+  "module": "src/chameleon-textarea.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/textarea",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Chameleon textarea",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/textarea/tsconfig.json
+++ b/packages/textarea/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]

--- a/packages/toast/__tests__/chameleon-toast.test.ts
+++ b/packages/toast/__tests__/chameleon-toast.test.ts
@@ -1,6 +1,6 @@
 import { litFixture, html, expect } from "@open-wc/testing";
 import sinon from "sinon";
-import "../src/chameleon-toast";
+import "@chameleon-ds/toast/src/chameleon-toast";
 
 const fixture = html`
   <chameleon-toast></chameleon-toast>

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/toast",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Chameleon toast",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -9,11 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/MaritzSTL/chameleon.git"
   },
-  "main": "dist/chameleon-toast.js",
-  "module": "dist/chameleon-toast.js",
+  "main": "src/chameleon-toast.js",
+  "module": "src/chameleon-toast.js",
   "files": [
-    "/src/",
-    "/dist/"
+    "/src/"
   ],
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/toast/tsconfig.json
+++ b/packages/toast/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__"]


### PR DESCRIPTION
This PR should do the following:

* change `tsc` to output into the src/ folder for better ts/js interop
* changed imports for testing to be scoped package imports