### PR TITLE
Default href to null

### DIFF
--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/button",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Chameleon button",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/button/src/chameleon-button.ts
+++ b/packages/button/src/chameleon-button.ts
@@ -38,7 +38,7 @@ export default class ChameleonButton extends LitElement {
 
   // Element has an href
   @property({ type: String, reflect: true })
-  "href" = "";
+  "href" = null;
 
   // Element should open href in new tab/window
   @property({ type: Boolean, reflect: true })


### PR DESCRIPTION
Set the default href of a button to null so we're not getting `href=(unknown)` everywhere.