### PR TITLE
Closing multiselect options when you click outside of the list

### DIFF
--- a/packages/multiselect/src/chameleon-multiselect.ts
+++ b/packages/multiselect/src/chameleon-multiselect.ts
@@ -18,15 +18,24 @@ export default class ChameleonMultiselect extends LitElement {
   constructor() {
     super();
     this.addEventListener("remove-chip", <EventListener>this.handleChipClose);
+    document.addEventListener("click", <EventListener>this.closeOptionsList);
+    document.addEventListener("chameleon-multiselect.close", () => {
+      this.active = false;
+    });
   }
 
   /**
    * Lifecycle Methods
    */
   disconnectedCallback() {
-    this.removeEventListener("remove-chip", <EventListener>(
-      this.handleChipClose
-    ));
+    this.removeEventListener(
+      "remove-chip",
+      <EventListener>this.handleChipClose
+    );
+    document.removeEventListener("click", <EventListener>this.closeOptionsList);
+    document.removeEventListener("chameleon-multiselect.close", () => {
+      this.active = false;
+    });
   }
 
   /**
@@ -90,7 +99,7 @@ export default class ChameleonMultiselect extends LitElement {
       >
         ${this.renderedSelectedOptions}
         <input
-          class="${classMap({
+          class="multiselect-input ${classMap({
             "tags-active": this.selectedOptions.length > 0
           })}"
           type="text"
@@ -268,6 +277,25 @@ export default class ChameleonMultiselect extends LitElement {
     ];
 
     this.dispatchChangeEvent();
+  }
+
+  private closeOptionsList(e: CustomEvent): void {
+    if (
+      e.composedPath &&
+      e.composedPath()[0] &&
+      (<HTMLElement>e.composedPath()[0]).classList
+    ) {
+      const classes = Array.from((<HTMLElement>e.composedPath()[0]).classList);
+
+      if (classes.includes("multiselect-input")) {
+        // Early return if the selector isn't open yet
+        e.stopPropagation();
+        return;
+      } else {
+        // Close selector if click is anywhere but inside the selector
+        this.dispatchEvent(new CustomEvent("chameleon-multiselect.close"));
+      }
+    }
   }
 
   private dispatchChangeEvent(): void {


### PR DESCRIPTION
This change will close the multiselect options list when you click outside of the component.