### PR TITLE
Allow table row prop to be any type

### DIFF
--- a/packages/table/types/index.ts
+++ b/packages/table/types/index.ts
@@ -21,7 +21,7 @@ export type Row = {
   showDetails?: boolean;
   details?: Row[];
 } & {
-  [key: string]: string | string[];
+  [key: string]: any;
 };
 
 export type FilterItems = FilterItem[];


### PR DESCRIPTION
The unknown props passed to a row can't be limited to a string and need to be listed as any type