### PR TITLE
making secondary button theme color transparent

### DIFF
--- a/packages/button/src/chameleon-button-style.ts
+++ b/packages/button/src/chameleon-button-style.ts
@@ -69,7 +69,7 @@ export default css`
   }
 
   .secondary {
-    background-color: var(--color-surface, #ffffff);
+    background-color: unset;
     color: var(--button-text-color);
   }
 


### PR DESCRIPTION
If the background color of a div is not white, we want the button color to be transparent instead of white.