### PR TITLE
adjusting the required attribute on input to not set invalid immediately

### DIFF
--- a/.storybook/stories/input.stories.ts
+++ b/.storybook/stories/input.stories.ts
@@ -35,6 +35,7 @@ stories.add(
     const label = text("Label", "");
     const error = text("Error", "");
     const placeholder = text("Placeholder", "Text...");
+    const requiredField = boolean("Required", false);
     const typeOptions = {
       Text: "text",
       Password: "password",
@@ -49,6 +50,7 @@ stories.add(
 
     return html`
       <chameleon-input
+        ?requiredField="${requiredField}"
         ?disabled="${disabled}"
         ?toggleable="${toggleable}"
         .type="${typeSelection}"
@@ -70,6 +72,7 @@ stories.add(
     const label = text("Label", "");
     const error = text("Error", "");
     const placeholder = text("Placeholder", "Text...");
+    const requiredField = boolean("Required", false);
     const typeOptions = {
       Text: "text",
       Password: "password",
@@ -84,6 +87,7 @@ stories.add(
 
     return html`
       <chameleon-input
+        ?requiredField="${requiredField}"
         ?disabled="${disabled}"
         ?toggleable="${toggleable}"
         icon-left
@@ -108,6 +112,7 @@ stories.add(
     const label = text("Label", "");
     const error = text("Error", "");
     const placeholder = text("Placeholder", "Text...");
+    const requiredField = boolean("Required", false);
     const typeOptions = {
       Text: "text",
       Password: "password",
@@ -122,6 +127,7 @@ stories.add(
 
     return html`
       <chameleon-input
+        ?requiredField="${requiredField}"
         ?disabled="${disabled}"
         ?toggleable="${toggleable}"
         icon-right

--- a/packages/input/__tests__/chameleon-input.test.ts
+++ b/packages/input/__tests__/chameleon-input.test.ts
@@ -120,6 +120,15 @@ describe("chameleon-input", () => {
     expect(checkValidity.calledImmediatelyAfter(handleBlur));
   });
 
+  it("_handleBlur calls checkRequired", () => {
+    const checkRequired = sinon.spy(element, "_checkRequired");
+    const handleBlur = sinon.spy(element, "_handleBlur");
+
+    element._handleBlur();
+
+    expect(checkRequired.calledImmediatelyAfter(handleBlur));
+  });
+
   it("_handleBlur else path", () => {
     element.checkValidity = sinon.stub(() => false);
     element._handleBlur();
@@ -152,5 +161,13 @@ describe("chameleon-input", () => {
     element._toggleType();
 
     expect(element.type).to.equal("text");
+  });
+
+  it("checkRequired sets required attribute if there's no input", () => {
+    element.value = "";
+    element.requiredField = true;
+    element._checkRequired();
+
+    expect(element._el).to.have.attribute("required");
   });
 });

--- a/packages/input/src/chameleon-input.ts
+++ b/packages/input/src/chameleon-input.ts
@@ -41,11 +41,15 @@ export default class ChameleonInput extends LitElement {
 
   // A Boolean which, if true, indicates that the input must have a value before the form can be submitted
   @property({ type: Boolean, reflect: true })
-  required = false;
+  requiredField = false;
 
   // A Boolean which, if present and the input type is 'password', allows visibility of password characters to be toggled
   @property({ type: Boolean, reflect: true })
   toggleable = false;
+
+  // A Boolean which, if true, indicates that the input field has had a blur event
+  @property({ type: Boolean, reflect: true })
+  touched = false;
 
   // A string indicating which input type the <input> element represents
   @property({ type: String, reflect: true })
@@ -144,7 +148,7 @@ export default class ChameleonInput extends LitElement {
             ?autofocus="${this.autofocus}"
             ?disabled="${this.disabled}"
             ?readonly="${this.readonly}"
-            ?required="${this.required}"
+            ?requiredField="${this.requiredField}"
             @input="${this._handleInput}"
             @blur="${this._handleBlur}"
             @invalid="${this._handleInvalid}"
@@ -162,7 +166,7 @@ export default class ChameleonInput extends LitElement {
             ?autofocus="${this.autofocus}"
             ?disabled="${this.disabled}"
             ?readonly="${this.readonly}"
-            ?required="${this.required}"
+            ?requiredField="${this.requiredField}"
             @input="${this._handleInput}"
             @blur="${this._handleBlur}"
             @invalid="${this._handleInvalid}"
@@ -241,8 +245,17 @@ export default class ChameleonInput extends LitElement {
     }
   }
 
+  _checkRequired(): void {
+    if (this.requiredField && this.value.length === 0) {
+      if (this._el !== null) {
+        this._el.setAttribute("required", "");
+      }
+    }
+  }
+
   _handleInput(e: any): void {
     this.value = e.target.value;
+    this._checkRequired();
 
     this.dispatchEvent(
       new CustomEvent("chameleon.input.input", {
@@ -256,6 +269,7 @@ export default class ChameleonInput extends LitElement {
   }
 
   _handleBlur(): void {
+    this._checkRequired();
     const elementValid = this.checkValidity();
     if (elementValid) this.validationMessage = "";
   }


### PR DESCRIPTION
Delaying required's check for input until after blur or input, bug #225 