### PR TITLE
redo noStepper

### DIFF
--- a/.storybook/stories/input.stories.ts
+++ b/.storybook/stories/input.stories.ts
@@ -36,6 +36,10 @@ stories.add(
     const error = text("Error", "");
     const placeholder = text("Placeholder", "Text...");
     const requiredField = boolean("Required", false);
+    const noStepper = boolean(
+      "Hide increment arrows/disable incrementing",
+      false
+    );
     const typeOptions = {
       Text: "text",
       Password: "password",
@@ -52,6 +56,7 @@ stories.add(
       <chameleon-input
         ?requiredField="${requiredField}"
         ?disabled="${disabled}"
+        ?noStepper="${noStepper}"
         ?toggleable="${toggleable}"
         .type="${typeSelection}"
         .placeholder="${placeholder}"
@@ -73,6 +78,10 @@ stories.add(
     const error = text("Error", "");
     const placeholder = text("Placeholder", "Text...");
     const requiredField = boolean("Required", false);
+    const noStepper = boolean(
+      "Hide increment arrows/disable incrementing",
+      false
+    );
     const typeOptions = {
       Text: "text",
       Password: "password",
@@ -89,6 +98,7 @@ stories.add(
       <chameleon-input
         ?requiredField="${requiredField}"
         ?disabled="${disabled}"
+        ?noStepper="${noStepper}"
         ?toggleable="${toggleable}"
         icon-left
         .type="${typeSelection}"
@@ -113,6 +123,10 @@ stories.add(
     const error = text("Error", "");
     const placeholder = text("Placeholder", "Text...");
     const requiredField = boolean("Required", false);
+    const noStepper = boolean(
+      "Hide increment arrows/disable incrementing",
+      false
+    );
     const typeOptions = {
       Text: "text",
       Password: "password",
@@ -129,6 +143,7 @@ stories.add(
       <chameleon-input
         ?requiredField="${requiredField}"
         ?disabled="${disabled}"
+        ?noStepper="${noStepper}"
         ?toggleable="${toggleable}"
         icon-right
         .type="${typeSelection}"

--- a/packages/input/__tests__/chameleon-input.test.ts
+++ b/packages/input/__tests__/chameleon-input.test.ts
@@ -170,4 +170,20 @@ describe("chameleon-input", () => {
 
     expect(element._el).to.have.attribute("required");
   });
+
+  it("_acceptInput disables up-arrow key to increment value if noStepper is true", () => {
+    element.value = "5";
+    element.noStepper = true;
+    element._acceptInput({ e: { which: "40" } });
+
+    expect(element.value).to.equal("5");
+  });
+
+  it("_acceptInput disables down-arrow key to decrement value if noStepper is true", () => {
+    element.value = "5";
+    element.noStepper = true;
+    element._acceptInput({ e: { which: "38" } });
+
+    expect(element.value).to.equal("5");
+  });
 });

--- a/packages/input/src/chameleon-input-style.ts
+++ b/packages/input/src/chameleon-input-style.ts
@@ -116,4 +116,13 @@ export default css`
   ::slotted([slot="icon-right"]) {
     right: 13px;
   }
+
+  .no-stepper input[type="number"]::-webkit-inner-spin-button,
+  .no-stepper input[type="number"]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  .no-stepper input[type="number"] {
+    -moz-appearance: textfield;
+  }
 `;

--- a/packages/input/src/chameleon-input.ts
+++ b/packages/input/src/chameleon-input.ts
@@ -35,6 +35,10 @@ export default class ChameleonInput extends LitElement {
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
+  // A Boolean attribute which, if true, indicates that the input with number type will not display increment arrows
+  @property({ type: Boolean, reflect: true })
+  noStepper = false;
+
   // A Boolean attribute which, if true, indicates that the input cannot be edited
   @property({ type: Boolean, reflect: true })
   readonly = false;
@@ -101,7 +105,8 @@ export default class ChameleonInput extends LitElement {
         ${classMap({
           "component-wrapper": true,
           invalid: this._invalidState,
-          disabled: this.disabled
+          disabled: this.disabled,
+          "no-stepper": this.noStepper
         })}"
       >
         <div
@@ -152,6 +157,7 @@ export default class ChameleonInput extends LitElement {
             @input="${this._handleInput}"
             @blur="${this._handleBlur}"
             @invalid="${this._handleInvalid}"
+            @keydown="${this._acceptInput}"
           />
         `;
       case "text":
@@ -170,6 +176,7 @@ export default class ChameleonInput extends LitElement {
             @input="${this._handleInput}"
             @blur="${this._handleBlur}"
             @invalid="${this._handleInvalid}"
+            @keydown="${this._acceptInput}"
           />
         `;
     }
@@ -277,6 +284,13 @@ export default class ChameleonInput extends LitElement {
   _handleInvalid(): void {
     this.validationMessage =
       this._el !== null ? this._el.validationMessage : "";
+  }
+
+  _acceptInput(e: any): boolean {
+    if (this.noStepper && (e.which === 38 || e.which === 40)) {
+      e.preventDefault();
+      return false;
+    } else return true;
   }
 
   get warningIcon(): SVGTemplateResult {


### PR DESCRIPTION
We need the option to hide the incrementing arrows on the input field when input is set to number type, and in addition to not displaying those arrows, the up and down arrows on the keyboard should be disabled from incrementing an entered value.