### PR TITLE
Option to make the whole accordion header clickable and add subheader

### DIFF
--- a/.storybook/stories/accordions.stories.ts
+++ b/.storybook/stories/accordions.stories.ts
@@ -6,28 +6,45 @@ import "@chameleon-ds/accordions/src/index";
 import "@chameleon-ds/button";
 
 const stories = storiesOf("Accordions", module);
+const faq = [
+  { question: "Who are you?", answer: "Who, who" },
+  { question: "What is love?", answer: "Baby don't hurt me" },
+  {
+    question: "Why do birds suddenly appear every time you are near?",
+    answer: "Just like me, they long to be close to you"
+  }
+];
 
 stories.addDecorator(withKnobs);
 
+stories.add("New basic accordions with default icons", () => {
+  return html`
+    <chameleon-accordions style="--accordion-width: 600px;">
+      ${faq.map(
+        faq => html`
+          <chameleon-accordion>
+            <h3 slot="header">${faq.question}</h3>
+            <div slot="panel">${faq.answer}</div>
+          </chameleon-accordion>
+        `
+      )}
+    </chameleon-accordions>
+  `;
+});
+
 stories.add(
-  "Text-only accordions",
+  "Accordions with clickable headers",
   () => {
     return html`
-      <chameleon-accordions style="--accordion-width: 400px;">
-        <chameleon-accordion>
-          <h3 slot="header">Who are you?</h3>
-          <div slot="panel">Who, who</div>
-        </chameleon-accordion>
-        <chameleon-accordion>
-          <h3 slot="header">What is love?</h3>
-          <div slot="panel">Baby don't hurt me</div>
-        </chameleon-accordion>
-        <chameleon-accordion>
-          <h3 slot="header">
-            Why do birds suddenly appear every time you are near?
-          </h3>
-          <div slot="panel">Just like me, they long to be close to you</div>
-        </chameleon-accordion>
+      <chameleon-accordions style="--accordion-width: 600px;">
+        ${faq.map(
+          faq => html`
+            <chameleon-accordion clickable>
+              <h3 slot="header">${faq.question}</h3>
+              <div slot="panel">${faq.answer}</div>
+            </chameleon-accordion>
+          `
+        )}
       </chameleon-accordions>
     `;
   },
@@ -35,7 +52,7 @@ stories.add(
 );
 
 stories.add(
-  "Text button accordions",
+  "Accordions with custom icons in fixed position",
   () => {
     return html`
       <style>

--- a/.storybook/stories/accordions.stories.ts
+++ b/.storybook/stories/accordions.stories.ts
@@ -61,7 +61,7 @@ stories.add(
         }
         chameleon-accordion {
           background-color: white;
-          padding-left: 22px;
+          padding: 0 22px;
         }
         chameleon-accordion:not(:last-of-type) {
           margin-bottom: 12px;

--- a/.storybook/stories/accordions.stories.ts
+++ b/.storybook/stories/accordions.stories.ts
@@ -33,25 +33,6 @@ stories.add("New basic accordions with default icons", () => {
 });
 
 stories.add(
-  "Accordions with clickable headers",
-  () => {
-    return html`
-      <chameleon-accordions style="--accordion-width: 600px;">
-        ${faq.map(
-          faq => html`
-            <chameleon-accordion clickable>
-              <h3 slot="header">${faq.question}</h3>
-              <div slot="panel">${faq.answer}</div>
-            </chameleon-accordion>
-          `
-        )}
-      </chameleon-accordions>
-    `;
-  },
-  { info: { inline: true } }
-);
-
-stories.add(
   "Accordions with custom icons in fixed position",
   () => {
     return html`
@@ -102,6 +83,61 @@ stories.add(
           <h3 slot="header">Things</h3>
           <div slot="panel">Candy canes</div>
         </chameleon-accordion>
+      </chameleon-accordions>
+    `;
+  },
+  { info: { inline: true } }
+);
+
+stories.add(
+  "Accordions with clickable headers",
+  () => {
+    return html`
+      <chameleon-accordions style="--accordion-width: 600px;">
+        ${faq.map(
+          faq => html`
+            <chameleon-accordion clickable>
+              <h3 slot="header">${faq.question}</h3>
+              <div slot="panel">${faq.answer}</div>
+            </chameleon-accordion>
+          `
+        )}
+      </chameleon-accordions>
+    `;
+  },
+  { info: { inline: true } }
+);
+
+stories.add(
+  "Accordions with clickable headers including subheaders",
+  () => {
+    return html`
+      <style>
+        .subheader {
+          display: flex;
+          justify-content: space-between;
+        }
+        .answer {
+          padding: 1rem 0;
+          background-color: lightgrey;
+        }
+      </style>
+      <chameleon-accordions style="--accordion-width: 600px;">
+        ${faq.map(
+          faq => html`
+            <chameleon-accordion clickable fixed>
+              <span slot="toggle-icon">Edit</span>
+              <h3 slot="header">${faq.question}</h3>
+              <div slot="subheader" class="subheader">
+                <span
+                  >Subheader message goes here for additional information</span
+                >
+                <span>0 people</span>
+              </div>
+              <div slot="panel" class="answer">${faq.answer}</div>
+            </chameleon-accordion>
+          `
+        )}
       </chameleon-accordions>
     `;
   },

--- a/packages/accordion/src/chameleon-accordion-style.ts
+++ b/packages/accordion/src/chameleon-accordion-style.ts
@@ -9,6 +9,10 @@ export default css`
   }
   .header {
     display: flex;
+    flex-direction: column;
+  }
+  .header-button-div {
+    display: flex;
     justify-content: space-between;
     align-items: baseline;
   }

--- a/packages/accordion/src/chameleon-accordion-style.ts
+++ b/packages/accordion/src/chameleon-accordion-style.ts
@@ -12,6 +12,9 @@ export default css`
     justify-content: space-between;
     align-items: baseline;
   }
+  .clickable {
+    cursor: pointer;
+  }
   /* ::slotted([slot="panel"]) {
     transform: translateY(100%);
     transition: transform 0.3s ease-in-out;

--- a/packages/accordion/src/chameleon-accordion.ts
+++ b/packages/accordion/src/chameleon-accordion.ts
@@ -21,6 +21,8 @@ export default class ChameleonAccordion extends LitElement {
    * Properties
    */
   @property({ type: Boolean, reflect: true })
+  clickable = false;
+  @property({ type: Boolean, reflect: true })
   expanded = false;
   @property({ type: Boolean, reflect: true })
   fixed = false;
@@ -30,20 +32,43 @@ export default class ChameleonAccordion extends LitElement {
    */
   render(): TemplateResult {
     return html`
-      <div class="header">
-        <slot name="header"></slot>
-        <chameleon-button
-          class="toggle-icon ${this.expanded && !this.fixed ? "rotated" : ""}"
-          icon-only
-          theme="text"
-          @click="${this.handleToggle}"
-          >${this.toggleIcon}</chameleon-button
-        >
-      </div>
+      ${this.clickable
+        ? html`
+            <div @click="${this.handleToggle}" class="header clickable">
+              <slot name="header"></slot>
+              <chameleon-button
+                class="toggle-icon ${this.expanded && !this.fixed
+                  ? "rotated"
+                  : ""}"
+                icon-only
+                theme="text"
+                @click="${(e: any) => this.disregardToggle(e)}"
+                >${this.toggleIcon}</chameleon-button
+              >
+            </div>
+          `
+        : html`
+            <div class="header">
+              <slot name="header"></slot>
+              <chameleon-button
+                class="toggle-icon ${this.expanded && !this.fixed
+                  ? "rotated"
+                  : ""}"
+                icon-only
+                theme="text"
+                @click="${this.handleToggle}"
+                >${this.toggleIcon}</chameleon-button
+              >
+            </div>
+          `}
       <div class="panel ${this.expanded ? "expanded" : "collapsed"}">
         <slot name="panel"></slot>
       </div>
     `;
+  }
+
+  disregardToggle(e: any) {
+    e.preventDefault();
   }
 
   handleToggle(): void {

--- a/packages/accordion/src/chameleon-accordion.ts
+++ b/packages/accordion/src/chameleon-accordion.ts
@@ -35,30 +35,36 @@ export default class ChameleonAccordion extends LitElement {
       ${this.clickable
         ? html`
             <div @click="${this.handleToggle}" class="header clickable">
-              <slot name="header"></slot>
-              <chameleon-button
-                class="toggle-icon ${this.expanded && !this.fixed
-                  ? "rotated"
-                  : ""}"
-                icon-only
-                theme="text"
-                @click="${(e: any) => this.disregardToggle(e)}"
-                >${this.toggleIcon}</chameleon-button
-              >
+              <div class="header-button-div">
+                <slot name="header"></slot>
+                <chameleon-button
+                  class="toggle-icon ${this.expanded && !this.fixed
+                    ? "rotated"
+                    : ""}"
+                  icon-only
+                  theme="text"
+                  @click="${(e: any) => this.disregardToggle(e)}"
+                  >${this.toggleIcon}</chameleon-button
+                >
+              </div>
+              <slot name="subheader"></slot>
             </div>
           `
         : html`
             <div class="header">
-              <slot name="header"></slot>
-              <chameleon-button
-                class="toggle-icon ${this.expanded && !this.fixed
-                  ? "rotated"
-                  : ""}"
-                icon-only
-                theme="text"
-                @click="${this.handleToggle}"
-                >${this.toggleIcon}</chameleon-button
-              >
+              <div class="header-button-div">
+                <slot name="header"></slot>
+                <chameleon-button
+                  class="toggle-icon ${this.expanded && !this.fixed
+                    ? "rotated"
+                    : ""}"
+                  icon-only
+                  theme="text"
+                  @click="${this.handleToggle}"
+                  >${this.toggleIcon}</chameleon-button
+                >
+              </div>
+              <slot name="subheader"></slot>
             </div>
           `}
       <div class="panel ${this.expanded ? "expanded" : "collapsed"}">


### PR DESCRIPTION
In some instances we require the whole accordion header to be clickable. (Closes #257)

Also here I've added the option to add a subheader that spans the full width of the accordion, which is also needed. (Closes #275)