### PR TITLE
keeps the loader inside the button

### DIFF
--- a/packages/button/src/chameleon-button-style.ts
+++ b/packages/button/src/chameleon-button-style.ts
@@ -114,7 +114,7 @@ export default css`
     margin: 0.5rem 0;
     position: absolute;
     top: 0;
-    width: 100%;
+    width: 25%;
   }
 
   /* If the loading icon is rendered, hide the rest of the button content */


### PR DESCRIPTION
<img width="118" alt="Screen Shot 2020-03-05 at 12 45 13 PM" src="https://user-images.githubusercontent.com/22972431/76014517-5d0be500-5edf-11ea-803f-dadb9a3f2588.png">
