### PR TITLE
feat(sheet): makes config configurable to enable nested overlay use

### DIFF
--- a/packages/sheet/package.json
+++ b/packages/sheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/sheet",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Chameleon sheet",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/sheet/package.json
+++ b/packages/sheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/sheet",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Chameleon sheet",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/sheet/package.json
+++ b/packages/sheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/sheet",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Chameleon sheet",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/sheet/src/chameleon-sheet.ts
+++ b/packages/sheet/src/chameleon-sheet.ts
@@ -1,8 +1,14 @@
 import { OverlayMixin } from "@lion/overlays";
-import { LitElement, html } from "lit-element";
+import { LitElement, html, property } from "lit-element";
 
 export class ChameleonSheet extends OverlayMixin(LitElement) {
   __toggle!: () => void;
+
+  @property({ type: Boolean }) trapsKeyboardFocus = true;
+  @property({ type: Boolean }) hasBackdrop = true;
+  @property({ type: Boolean }) hidesOnOutsideClick = true;
+  @property({ type: Boolean }) hidesOnEsc = true;
+  @property({ type: Boolean }) preventsScroll = true;
 
   // eslint-disable-next-line class-methods-use-this
   _defineOverlayConfig() {
@@ -11,12 +17,12 @@ export class ChameleonSheet extends OverlayMixin(LitElement) {
       viewportConfig: {
         placement: "right",
       },
-      hasBackdrop: true,
-      hidesOnEsc: true,
-      hidesOnOutsideClick: true,
-      preventsScroll: true,
       handleAccessibility: true,
-      trapsKeyboardFocus: true,
+      hasBackdrop: this.hasBackdrop,
+      hidesOnEsc: this.hidesOnEsc,
+      hidesOnOutsideClick: this.hidesOnOutsideClick,
+      preventsScroll: this.preventsScroll,
+      trapsKeyboardFocus: this.trapsKeyboardFocus,
     };
   }
 


### PR DESCRIPTION
In cases where you might open a dialog from a sheet, we need to configure down some of the default behavior so people can interact with the dialog. This PR adds that.

Specifically, setting these properties this way will enable that:
```
<chameleon-sheet
  .hasBackdrop="${false}"
  .trapsKeyboardFocus="${false}"
  .hidesOnEsc="${false}"
  .hidesOnOutsideClick="${false}">
```
