### PR TITLE
Sheet/closeicon fix

### DIFF
--- a/packages/sheet/__tests__/sheet-content.test.js
+++ b/packages/sheet/__tests__/sheet-content.test.js
@@ -41,6 +41,9 @@ describe("sheet-content", () => {
     expect(el.dismissable).to.equal(true);
   });
   it("displays close icon when dismissable", () => {
+    expect(
+      el.shadowRoot.querySelector(".close-icon").innerHTML.includes("svg")
+    ).to.equal(true);
     expect(el.shadowRoot.querySelector(".close-icon")).to.not.equal(null);
   });
   it("doesn't show close icon when not dismissable", async () => {

--- a/packages/sheet/package.json
+++ b/packages/sheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/sheet",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Chameleon sheet",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/sheet/src/SheetContent.js
+++ b/packages/sheet/src/SheetContent.js
@@ -1,7 +1,9 @@
 import { LitElement, html, svg, css, property } from "lit-element";
 
 export class SheetContent extends LitElement {
-  _defaultCloseIcon = svg`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`;
+  static get closeIcon() {
+    return svg`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`;
+  }
 
   static get styles() {
     return [
@@ -69,7 +71,7 @@ export class SheetContent extends LitElement {
   get defaultCloseIcon() {
     return html`
       <span class="close-icon" @click="${this.close}" aria-role="button">
-        ${SheetContent._defaultCloseIcon}
+        ${SheetContent.closeIcon}
       </span>
     `;
   }


### PR DESCRIPTION
* icon now appears correctly
* test checks for it

Moved from a ts-friendly `_declaration=` to a `static get()`