### PR TITLE
Cz/accordion upgrade

### DIFF
--- a/__snapshots__/chameleon-accordion.md
+++ b/__snapshots__/chameleon-accordion.md
@@ -1,0 +1,76 @@
+# `chameleon-accordion`
+
+#### `renders !expanded correctly`
+
+```html
+<div class="header">
+  <div class="header-toggle">
+    <span class="toggle-icon">
+    </span>
+    <slot name="header">
+    </slot>
+  </div>
+  <slot name="subheader">
+  </slot>
+</div>
+<div class="collapsed panel">
+  <slot name="panel">
+  </slot>
+</div>
+
+```
+
+```html
+<div class="header">
+  <div class="header-toggle">
+    <span class="toggle-icon">
+    </span>
+    <slot name="header">
+    </slot>
+  </div>
+  <slot name="subheader">
+  </slot>
+</div>
+<div class="collapsed panel">
+  <slot name="panel">
+  </slot>
+</div>
+```
+
+#### `renders expanded correctly`
+
+```html
+<div class="header">
+  <div class="header-toggle">
+    <span class="rotate toggle-icon">
+    </span>
+    <slot name="header">
+    </slot>
+  </div>
+  <slot name="subheader">
+  </slot>
+</div>
+<div class="expanded panel">
+  <slot name="panel">
+  </slot>
+</div>
+
+```
+
+```html
+<div class="header">
+  <div class="header-toggle">
+    <span class="rotate toggle-icon">
+    </span>
+    <slot name="header">
+    </slot>
+  </div>
+  <slot name="subheader">
+  </slot>
+</div>
+<div class="expanded panel">
+  <slot name="panel">
+  </slot>
+</div>
+```
+

--- a/__snapshots__/chameleon-accordions.md
+++ b/__snapshots__/chameleon-accordions.md
@@ -4,9 +4,9 @@
 
 ```html
 <chameleon-accordions>
-  <chameleon-accordion uuid="1tvd574olb">
+  <chameleon-accordion uuid="6agt6jpik8">
   </chameleon-accordion>
-  <chameleon-accordion uuid="k23a4sp73h">
+  <chameleon-accordion uuid="wypd9znp3a">
   </chameleon-accordion>
 </chameleon-accordions>
 

--- a/__snapshots__/chameleon-accordions.md
+++ b/__snapshots__/chameleon-accordions.md
@@ -4,9 +4,9 @@
 
 ```html
 <chameleon-accordions>
-  <chameleon-accordion uuid="6agt6jpik8">
+  <chameleon-accordion uid="6agt6jpik8">
   </chameleon-accordion>
-  <chameleon-accordion uuid="wypd9znp3a">
+  <chameleon-accordion uid="wypd9znp3a">
   </chameleon-accordion>
 </chameleon-accordions>
 

--- a/__snapshots__/chameleon-accordions.md
+++ b/__snapshots__/chameleon-accordions.md
@@ -1,0 +1,20 @@
+# `chameleon-accordions`
+
+#### `renders any slotted content`
+
+```html
+<chameleon-accordions>
+  <chameleon-accordion uuid="1tvd574olb">
+  </chameleon-accordion>
+  <chameleon-accordion uuid="k23a4sp73h">
+  </chameleon-accordion>
+</chameleon-accordions>
+
+```
+
+```html
+<slot>
+</slot>
+
+```
+

--- a/packages/accordions/README.md
+++ b/packages/accordions/README.md
@@ -29,6 +29,12 @@ export default {
 | `accentColor` | String  | `null`        | The CSS color value to be applied to the accent color |
 | `uid`         | String  | `""`          | A random/unique identifier for this accordion         |
 
+If you're nesting accordions inside your own components and subscribing them to `chameleon-accordions` and need to track whether or not they're `expanded`, you can use:
+
+| Event Name | Composed | Bubbles | Description                                                 |
+| ---------- | -------- | ------- | ----------------------------------------------------------- |
+| `expanded` | `false`  | `false` | Dispatched when the `accordionEl.expanded` property changes |
+
 ## CSS Properties
 
 ### chameleon-accordions

--- a/packages/accordions/README.md
+++ b/packages/accordions/README.md
@@ -16,9 +16,9 @@ export default {
 
 ### chameleon-accordions
 
-| Property Name   | Type(s) | Default Value | Description                                  |
-| --------------- | ------- | ------------- | -------------------------------------------- |
-| `expandedIndex` | Number  | `-1`          | Determines if the accordion appears expanded |
+| Property Name | Type(s) | Default Value | Description                                |
+| ------------- | ------- | ------------- | ------------------------------------------ |
+| `accordions`  | Array   | []            | Stores references to registered accordions |
 
 ### chameleon-accordion
 
@@ -27,6 +27,7 @@ export default {
 | `expanded`    | Boolean | `false`       | Determines if the accordion appears expanded          |
 | `caret`       | Boolean | `true`        | When false, the caret icon will not display           |
 | `accentColor` | String  | `null`        | The CSS color value to be applied to the accent color |
+| `uid`         | String  | `""`          | A random/unique identifier for this accordion         |
 
 ## CSS Properties
 
@@ -45,6 +46,8 @@ export default {
 ## Examples
 
 ### Default
+
+`<chameleon-accordions>` will automatically register any `<chameleon-accordion>` descendant and make sure only one accordion can be open at a time.
 
 ```js preview-story
 export const Default = () => html`
@@ -79,6 +82,44 @@ export const Default = () => html`
       </section>
     </chameleon-accordion>
   </chameleon-accordions>
+`;
+```
+
+### Individual Accordions
+
+If you don't want that, you can use `<chameleon-accordion>` on it's own!
+
+```js preview-story
+export const IndividualAccordions = () => html`
+  <chameleon-accordion>
+    <h4 slot="header">Tower Grove</h4>
+    <section slot="panel">
+      Tower Grove South is a neighborhood of south St. Louis, Missouri. Formerly
+      known as Oak Hill, Tower Grove South is bounded by Arsenal Street on the
+      north, Chippewa Street on the south, Kingshighway Boulevard on the west,
+      and Grand Boulevard on the east.
+    </section>
+  </chameleon-accordion>
+  <chameleon-accordion>
+    <h4 slot="header">Benton Park</h4>
+    <section slot="panel">
+      Benton Park is a neighborhood in southside St. Louis, Missouri, just west
+      of the Soulard neighborhood. The official boundaries of the area are
+      Gravois Avenue on the north, Cherokee Street on the south, I-55 on the
+      east, and Jefferson Avenue on the west.
+    </section>
+  </chameleon-accordion>
+  <chameleon-accordion>
+    <h4 slot="header">Soulard</h4>
+    <section slot="panel">
+      Known for its blues scene, buzzing Soulard has raucous bars with live
+      music alongside casual pizzerias, down-to-earth Southern restaurants and
+      seafood spots serving oysters and crawfish. Established in 1779, Soulard
+      Farmers Market displays a colorful spread of produce, meats and cheeses,
+      while the huge, 19th-century Anheuser-Busch Brewery offers tours. The
+      area’s lively annual Mardi Gras parade draws big crowds.
+    </section>
+  </chameleon-accordion>
 `;
 ```
 

--- a/packages/accordions/__tests__/chameleon-accordion.test.js
+++ b/packages/accordions/__tests__/chameleon-accordion.test.js
@@ -118,4 +118,17 @@ describe("chameleon-accordion", () => {
     );
     expect(el.toggleIcon).to.eql(el.defaultToggleIcon);
   });
+  it("dispatches expanded-changed event when expanded changes", async () => {
+    const spy = sinon.spy();
+    // first expanded-changed occurs as component instantiates
+    const el = await fixture(
+      html`<chameleon-accordion
+        @expanded-changed="${spy}"
+      ></chameleon-accordion>`
+    );
+    // trigger second expanded-changed
+    el.expanded = !el.expanded;
+    await el.updateComplete;
+    expect(spy.getCalls().length).to.equal(2);
+  });
 });

--- a/packages/accordions/__tests__/chameleon-accordion.test.js
+++ b/packages/accordions/__tests__/chameleon-accordion.test.js
@@ -1,0 +1,121 @@
+import { fixture, html, expect } from "@open-wc/testing";
+import sinon from "sinon";
+import "../chameleon-accordion.js";
+
+describe("chameleon-accordion", () => {
+  it("fires `accordion-connected` event in firstUpdated", async () => {
+    const spy = sinon.spy();
+    const el = await fixture(
+      html`<chameleon-accordion @accordion-connected=${spy}>
+        <h4 slot="header">Tower Grove</h4>
+        <section slot="panel">
+          Tower Grove South is a neighborhood of south St. Louis, Missouri.
+        </section>
+      </chameleon-accordion>`
+    );
+    expect(spy.called).to.equal(true);
+  });
+  it("determines __connected from `accordion-connected` event", async () => {
+    const handler = (e) => {
+      e.detail.connected = true;
+    };
+    const el = await fixture(
+      html`<chameleon-accordion
+        @accordion-connected=${handler}
+      ></chameleon-accordion>`
+    );
+
+    expect(el.__connected).to.equal(true);
+  });
+  it("renders !expanded correctly", async () => {
+    const el = await fixture(
+      html`<chameleon-accordion>
+        <h4 slot="header">Tower Grove</h4>
+        <section slot="panel">
+          Tower Grove South is a neighborhood of south St. Louis, Missouri.
+        </section>
+      </chameleon-accordion>`
+    );
+
+    expect(el).shadowDom.to.equalSnapshot();
+  });
+  it("renders expanded correctly", async () => {
+    const el = await fixture(
+      html`<chameleon-accordion .expanded="${true}">
+        <h4 slot="header">Tower Grove</h4>
+        <section slot="panel">
+          Tower Grove South is a neighborhood of south St. Louis, Missouri.
+        </section>
+      </chameleon-accordion>`
+    );
+
+    expect(el).shadowDom.to.equalSnapshot();
+  });
+  it("fires `accordion-disconnected` event on disconnectedCallback()", async () => {
+    const spy = sinon.spy();
+    const el = await fixture(
+      html`<div @accordion-disconnected="${spy}">
+        <chameleon-accordion></chameleon-accordion>
+      </div>`
+    );
+    const accordion = el.querySelector("chameleon-accordion");
+    accordion.disconnectedCallback();
+    // accordion.parentElement.removeChild(accordion);
+    expect(spy.called).to.equal(true);
+  });
+  it("toggles expanded if not connected", async () => {
+    const el = await fixture(
+      html`<chameleon-accordion>
+        <h4 slot="header">Tower Grove</h4>
+        <section slot="panel">
+          Tower Grove South is a neighborhood of south St. Louis, Missourah.
+        </section>
+      </chameleon-accordion>`
+    );
+
+    const initialState = el.expanded;
+    el.header.click();
+
+    expect(initialState).to.equal(false);
+    expect(el.expanded).to.equal(true);
+  });
+  it("fires toggle event if connected", async () => {
+    const spy = sinon.spy();
+    const el = await fixture(
+      html` <chameleon-accordion @toggle-accordion="${spy}">
+        <h4 slot="header">Tower Grove</h4>
+        <section slot="panel">
+          Tower Grove South is a neighborhood of south St. Louis, Missouri.
+        </section>
+      </chameleon-accordion>`
+    );
+
+    el.__connected = true;
+    el.header.click();
+    expect(spy.called).to.equal(true);
+    expect(el.expanded).to.equal(false);
+  });
+  it("accepts slotted toggle icon", async () => {
+    const el = await fixture(
+      html`<chameleon-accordion>
+        <span slot="toggle-icon">x</span>
+        <h4 slot="header">Tower Grove</h4>
+        <section slot="panel">
+          Tower Grove South is a neighborhood of south St. Louis, Missouri.
+        </section>
+      </chameleon-accordion>`
+    );
+    expect(el.toggleIconSlot.textContent).to.equal("x");
+  });
+  it("provides an svg by default", async () => {
+    const el = await fixture(
+      html`<chameleon-accordion>
+        <h4 slot="header">Tower Grove</h4>
+        <section slot="panel">
+          Tower Grove South is a neighborhood of south St. Louis, Missouri.
+        </section>
+      </chameleon-accordion>`
+    );
+    expect(el.toggleIcon).to.eql(el.defaultToggleIcon);
+  });
+});

--- a/packages/accordions/__tests__/chameleon-accordions.test.js
+++ b/packages/accordions/__tests__/chameleon-accordions.test.js
@@ -1,5 +1,4 @@
 import { litFixture, html, expect } from "@open-wc/testing";
-import sinon from "sinon";
 import "../chameleon-accordion.js";
 import "../chameleon-accordions.js";
 

--- a/packages/accordions/__tests__/chameleon-accordions.test.js
+++ b/packages/accordions/__tests__/chameleon-accordions.test.js
@@ -1,6 +1,5 @@
 import { litFixture, html, expect } from "@open-wc/testing";
 import sinon from "sinon";
-import { ChameleonAccordions } from "../index.js";
 import "../chameleon-accordion.js";
 import "../chameleon-accordions.js";
 
@@ -12,54 +11,48 @@ const fixture = html`
 `;
 
 describe("chameleon-accordions", () => {
-  let element;
+  let el;
 
   beforeEach(async () => {
-    element = await litFixture(fixture);
+    el = await litFixture(fixture);
   });
 
-  it("renders", async () => {
-    expect(Boolean(element.shadowRoot)).to.equal(true);
+  it("renders any slotted content", () => {
+    expect(el).dom.to.equalSnapshot({ ignoreAttributes: ["uuid"] });
+    expect(el).shadowDom.to.equalSnapshot();
   });
-
-  it("dispatches an event on handleToggle", () => {
-    const accordion = element.querySelector("chameleon-accordion");
-    const spy = sinon.spy(accordion, "dispatchEvent");
-
-    accordion.handleToggle();
-
-    expect(spy).to.be.calledOnce;
+  it("registers accordions on `accordion-connected`", () => {
+    expect(el.accordions.length).to.equal(2);
   });
+  it("unregisters accordions on `accordion-disconnected`", async () => {
+    const initialAccordions = Array.from(
+      el.querySelectorAll("chameleon-accordion")
+    ).map((acc) => acc.uuid);
+    const accordion = el.querySelector("chameleon-accordion");
+    const removedUuid = accordion.uuid;
 
-  it("throws error if no accordions are given", () => {
-    expect(() => new ChameleonAccordions().firstUpdated()).to.throw();
+    accordion.disconnectedCallback();
+
+    expect(initialAccordions.length).to.equal(2);
+    expect(el.accordions.length).to.equal(1);
+    expect(el.accordions.indexOf(removedUuid)).to.equal(-1);
   });
-
-  xit("applies rotated class to icon button if panel is open and fixed property is false", () => {
-    const accordion = element.querySelector("chameleon-accordion");
-    accordion.setAttribute("fixed", false);
-    accordion.handleToggle();
-
-    expect(() =>
-      accordion.shadowRoot.querySelector("chameleon-button")
-    ).to.have.class("rotated");
+  it("toggles targeted accordion on `toggle-accordion`", () => {
+    const accordion = el.querySelector("chameleon-accordion");
+    expect(accordion.expanded).to.equal(false);
+    accordion.header.click();
+    expect(accordion.expanded).to.equal(true);
   });
+  it("closes all other registered accordions of targeted accordion is expanded", () => {
+    const accordions = Array.from(el.querySelectorAll("chameleon-accordion"));
+    accordions[0].expanded = true;
 
-  xit("does not apply rotated class to icon button if panel is open and fixed property is true", () => {
-    const accordion = element.querySelector("chameleon-accordion");
-    accordion.setAttribute("fixed", true);
-    accordion.handleToggle();
+    expect(accordions[0].expanded).to.equal(true);
+    expect(accordions[1].expanded).to.equal(false);
 
-    expect(() =>
-      accordion.shadowRoot.querySelector(".toggle-icon")
-    ).not.to.have.class("rotated");
-  });
+    accordions[1].header.click();
 
-  it("updates expandedIndex", async () => {
-    element.expanded = -1;
-    const accordion = element.querySelector("chameleon-accordion");
-    accordion.handleToggle();
-
-    expect(element.expandedIndex).to.equal(0);
+    expect(accordions[0].expanded).to.equal(false);
+    expect(accordions[1].expanded).to.equal(true);
   });
 });

--- a/packages/accordions/__tests__/chameleon-accordions.test.js
+++ b/packages/accordions/__tests__/chameleon-accordions.test.js
@@ -18,7 +18,7 @@ describe("chameleon-accordions", () => {
   });
 
   it("renders any slotted content", () => {
-    expect(el).dom.to.equalSnapshot({ ignoreAttributes: ["uuid"] });
+    expect(el).dom.to.equalSnapshot({ ignoreAttributes: ["uid"] });
     expect(el).shadowDom.to.equalSnapshot();
   });
   it("registers accordions on `accordion-connected`", () => {
@@ -27,15 +27,15 @@ describe("chameleon-accordions", () => {
   it("unregisters accordions on `accordion-disconnected`", async () => {
     const initialAccordions = Array.from(
       el.querySelectorAll("chameleon-accordion")
-    ).map((acc) => acc.uuid);
+    ).map((acc) => acc.uid);
     const accordion = el.querySelector("chameleon-accordion");
-    const removedUuid = accordion.uuid;
+    const removedUid = accordion.uid;
 
     accordion.disconnectedCallback();
 
     expect(initialAccordions.length).to.equal(2);
     expect(el.accordions.length).to.equal(1);
-    expect(el.accordions.indexOf(removedUuid)).to.equal(-1);
+    expect(el.accordions.indexOf(removedUid)).to.equal(-1);
   });
   it("toggles targeted accordion on `toggle-accordion`", () => {
     const accordion = el.querySelector("chameleon-accordion");

--- a/packages/accordions/package.json
+++ b/packages/accordions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/accordions",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "Chameleon accordions",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/accordions/src/ChameleonAccordion.js
+++ b/packages/accordions/src/ChameleonAccordion.js
@@ -2,7 +2,7 @@ import { LitElement, property, svg, html, query } from "lit-element";
 import { classMap } from "lit-html/directives/class-map.js";
 import { ChameleonAccordionStyle } from "./ChameleonAccordionStyle.js";
 
-const uuid = () => Math.random().toString(36).substr(2, 10);
+const uid = () => Math.random().toString(36).substr(2, 10);
 
 export class ChameleonAccordion extends LitElement {
   /**
@@ -22,7 +22,7 @@ export class ChameleonAccordion extends LitElement {
   @property({ type: String })
   accentColor = null;
 
-  @property({ type: String, reflect: true }) uuid = "";
+  @property({ type: String, reflect: true }) uid = "";
 
   // Whether or not this accordion is connected to a grouping <chameleon-accordions>
   @property({ type: Boolean })
@@ -32,7 +32,7 @@ export class ChameleonAccordion extends LitElement {
 
   constructor() {
     super();
-    this.uuid = uuid();
+    this.uid = uid();
   }
 
   connectedCallback() {

--- a/packages/accordions/src/ChameleonAccordion.js
+++ b/packages/accordions/src/ChameleonAccordion.js
@@ -75,6 +75,10 @@ export class ChameleonAccordion extends LitElement {
         ".header"
       ).style.borderLeft = `7px solid var(--color-primary, #2c6fb7)`;
     }
+
+    if (changedProperties.has("expanded")) {
+      this.__dispatchExpandedChangedEvent();
+    }
   }
 
   __dispatchToggleEvent() {
@@ -84,6 +88,10 @@ export class ChameleonAccordion extends LitElement {
         composed: true,
       })
     );
+  }
+
+  __dispatchExpandedChangedEvent() {
+    this.dispatchEvent(new CustomEvent("expanded-changed"));
   }
 
   handleToggle() {

--- a/packages/accordions/src/ChameleonAccordions.js
+++ b/packages/accordions/src/ChameleonAccordions.js
@@ -36,9 +36,7 @@ export class ChameleonAccordions extends LitElement {
 
   _unregisterAccordion(e) {
     this.accordions = [
-      ...this.accordions.filter(
-        (accordion) => accordion.uuid !== e.target.uuid
-      ),
+      ...this.accordions.filter((accordion) => accordion.uid !== e.target.uid),
     ];
     e.preventDefault();
   }

--- a/packages/accordions/src/ChameleonAccordions.js
+++ b/packages/accordions/src/ChameleonAccordions.js
@@ -31,14 +31,14 @@ export class ChameleonAccordions extends LitElement {
   _registerAccordion(e) {
     this.accordions = [...this.accordions, e.target];
     e.detail.connected = true;
-    e.preventDefault();
+    e.stopPropagation();
   }
 
   _unregisterAccordion(e) {
     this.accordions = [
       ...this.accordions.filter((accordion) => accordion.uid !== e.target.uid),
     ];
-    e.preventDefault();
+    e.stopPropagation();
   }
 
   _handleToggle(e) {
@@ -53,5 +53,7 @@ export class ChameleonAccordions extends LitElement {
         .filter((accordion) => accordion !== accordionToToggle)
         .forEach((accordion) => (accordion.expanded = false));
     }
+
+    e.stopPropagation();
   }
 }

--- a/packages/accordions/src/ChameleonAccordions.js
+++ b/packages/accordions/src/ChameleonAccordions.js
@@ -45,7 +45,7 @@ export class ChameleonAccordions extends LitElement {
 
   _handleToggle(e) {
     const accordionToToggle = this.accordions.find(
-      (accordion) => accordion.uuid === e.target.uuid
+      (accordion) => accordion.uid === e.target.uid
     );
     accordionToToggle.expanded = !accordionToToggle.expanded;
 

--- a/packages/multiselect/__tests__/chameleon-multiselect.test.js
+++ b/packages/multiselect/__tests__/chameleon-multiselect.test.js
@@ -117,7 +117,6 @@ describe("chameleon-multiselect", () => {
         `
       );
       await fixture.updateComplete;
-      debugger;
       expect(fixture).shadowDom.to.equalSnapshot();
     });
 

--- a/scripts/linker.js
+++ b/scripts/linker.js
@@ -27,7 +27,7 @@ const allNames = await packageNames();
 
 console.log("In this directory, run:");
 console.log("");
-console.log(`\t npx lerna exec yarn link ${allNames.join(" ")}`);
+console.log(`\t npx lerna exec yarn link`);
 console.log("");
 console.log("To use these in target directory, run:");
 console.log("");

--- a/scripts/linker.js
+++ b/scripts/linker.js
@@ -27,7 +27,7 @@ const allNames = await packageNames();
 
 console.log("In this directory, run:");
 console.log("");
-console.log("\t npx lerna exec yarn link");
+console.log(`\t npx lerna exec yarn link ${allNames.join(" ")}`);
 console.log("");
 console.log("To use these in target directory, run:");
 console.log("");


### PR DESCRIPTION
This PR updates accordions to break them from needing to be in an immediate parent/child relationship.

> It would be great if the chameleon-accordion inside would communicate with chameleon-accordions regardless of nesting. Rule being, each chameleon-accordion registers itself with the closest chameleon-accordions ancestor. That way, we wouldn't have to mash a bunch of state together inside the component that renders them all out. We could build components that contained accordions, and those would work seamlessly with the chameleon-accordions container.

In `ChameleonAccordion`, when an accordion connects, it fires an event off:
```js
  connectedCallback() {
    super.connectedCallback();
    const event = new CustomEvent("accordion-connected", {
      composed: true,
      bubbles: true,
      detail: {
        connected: false,
      },
    });

    this.dispatchEvent(event);

    // chameleon-accordions will update event if it connects
    this.__connected = event.detail.connected;
  }
```

If it's inside an `ChameleonAccordions` based component, 
```js
  _registerAccordion(e) {
    this.accordions = [...this.accordions, e.target];
    e.detail.connected = true;
    e.preventDefault();
  }
```

It will set `connected` to true on the event. This will cause the specific accordion to send events around toggles, and defer to `ChameleonAccordions`. Otherwise, individual accordions will manage their own state:

```js
  handleToggle() {
    this.__connected
      ? this.__dispatchToggleEvent()
      : (this.expanded = !this.expanded);
  }
```

- [x] documentation update
- [x] determine version bump
- [x] should we use `useCapture` here for the event?
- [x] should we provide an "opt-out" so individual accordions don't attempt to connect?

Regarding breaking changes, I changed from the previous event name because it used a `expanded-changed` (a past-tense name) to imperatively command the accordions container to toggle it (meaning the event wasn't about something that happened, and was intended to be used imperatively). This is now named `toggle-accordion`. We could change it back for a potential minor version bump (or continue dispatching it so as not to break existing api). We could also hold off on this particular change until we address all events. Not sure what we might wanna do here.