### PR TITLE
Add new slots to accordion toggle icon

### DIFF
--- a/packages/accordions/package.json
+++ b/packages/accordions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chameleon-ds/accordions",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Chameleon accordions",
   "author": "Maritz Motivation Solutions, Inc.",
   "license": "MIT",

--- a/packages/accordions/src/ChameleonAccordion.js
+++ b/packages/accordions/src/ChameleonAccordion.js
@@ -104,6 +104,14 @@ export class ChameleonAccordion extends LitElement {
     return this.querySelector("[slot='toggle-icon']");
   }
 
+  get toggleIconSlotClosed() {
+    return this.querySelector("[slot='toggle-icon-closed']");
+  }
+
+  get toggleIconSlotExpanded() {
+    return this.querySelector("[slot='toggle-icon-expanded']");
+  }
+
   get defaultToggleIcon() {
     return svg`<svg
         xmlns="http://www.w3.org/2000/svg"
@@ -123,6 +131,11 @@ export class ChameleonAccordion extends LitElement {
 
   get toggleIcon() {
     // Return custom-slotted icon with svg default if not present
+    if (this.toggleIconSlotClosed && this.toggleIconSlotExpanded) {
+      return this.expanded
+        ? html`<slot name="toggle-icon-expanded"></slot>`
+        : html`<slot name="toggle-icon-closed"></slot>`;
+    }
     return this.toggleIconSlot
       ? html`<slot name="toggle-icon"></slot>`
       : this.defaultToggleIcon;


### PR DESCRIPTION
The accordion can be in an expanded or closed state but there's only one
icon definition (besides the default caret).  This adds two slots that,
if both are present, will switch the icon between the two depending on
toggle state